### PR TITLE
Hotfix v0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![codecov](https://codecov.io/gh/Kaiser-Yang/matrix-calculation-accelarator/graph/badge.svg?token=INWEC8613W)](https://codecov.io/gh/Kaiser-Yang/matrix-calculation-accelarator)
+[![codecov](https://codecov.io/gh/Kaiser-Yang/matrix-calculation-accelerator/graph/badge.svg?token=INWEC8613W)](https://codecov.io/gh/Kaiser-Yang/matrix-calculation-accelerator)
 
 # matrix-calculation-accelerator
 


### PR DESCRIPTION
Fix the `url` of `codecov`

Bump version up to `v0.1.1`.

The repository has been renamed. Therefore the original `url` of `codecov` is
invalid. And, we update the old `url` with the new valid one.