### PR TITLE
Fix clang tidy

### DIFF
--- a/src/include/matrix.h
+++ b/src/include/matrix.h
@@ -42,7 +42,7 @@ public:
     Matrix(const std::vector<std::vector<ELEMENT_TYPE>> &init);
 
     // Construct a matrix with shape and defaultValue
-    Matrix(const Shape &shape, const ELEMENT_TYPE &defaultValue);
+    inline Matrix(const Shape &shape, const ELEMENT_TYPE &defaultValue);
 
     // Construct a diagonal matrix, the diag is the diagonal elements
     // Matrix<>({1, 2, 3, 4}) will construct a matrix whose shape are 4 * 4,
@@ -55,15 +55,15 @@ public:
     // the other matrix's data will use static_cast<> to convert its type the same with current
     // matrix
     template <class T>
-    Matrix(const Matrix<T> &other);
+    inline Matrix(const Matrix<T> &other);
 
     // Move constructor
     // NOTE: only those which have the same ELEMENT_TYPE can use move constructor
-    Matrix(Matrix &&other) noexcept;
+    inline Matrix(Matrix &&other) noexcept;
 
     // Move assignment
     // NOTE: only those which have the same ELEMENT_TYPE can use move assignment
-    Matrix &operator=(Matrix &&other) noexcept;
+    inline Matrix &operator=(Matrix &&other) noexcept;
 
     // Copy assignment
     // If the other matrix's ELEMENT_TYPE is not same with current matrix,
@@ -88,26 +88,26 @@ public:
     Matrix<ELEMENT_TYPE> &operator=(const std::vector<std::vector<T>> &init);
 
     // get the reference to the element of i-th row, j-th column
-    ELEMENT_TYPE &get(size_t i, size_t j);
-    const ELEMENT_TYPE &get(size_t i, size_t j) const;
+    inline ELEMENT_TYPE &get(size_t i, size_t j);
+    inline const ELEMENT_TYPE &get(size_t i, size_t j) const;
 
     // get the date pointer
-    ELEMENT_TYPE *dataPtr();
-    const ELEMENT_TYPE *dataPtr() const;
+    inline ELEMENT_TYPE *dataPtr();
+    inline const ELEMENT_TYPE *dataPtr() const;
 
     // get the number of rows
-    size_t rows() const;
+    inline size_t rows() const;
 
     // get the number of columns
-    size_t columns() const;
+    inline size_t columns() const;
 
     // get the matrix's shape
-    Shape getShape() const;
+    inline Shape getShape() const;
 
     // Reshape the matrix
     // NOTE: this is only valid, when the new shape has the same number of elements with the old
     //       one
-    void reshape(const Shape &shape);
+    inline void reshape(const Shape &shape);
 
     // Make all the elements of the matrix be a new value
     void fill(const ELEMENT_TYPE &value);
@@ -516,12 +516,12 @@ Matrix<ELEMENT_TYPE> &Matrix<ELEMENT_TYPE>::operator=(const std::vector<std::vec
 }
 
 template <class ELEMENT_TYPE>
-ELEMENT_TYPE &Matrix<ELEMENT_TYPE>::get(size_t i, size_t j) {
+inline ELEMENT_TYPE &Matrix<ELEMENT_TYPE>::get(size_t i, size_t j) {
     assert(i < shape.rows && j < shape.columns);
     return data[i * shape.columns + j];
 }
 template <class ELEMENT_TYPE>
-const ELEMENT_TYPE &Matrix<ELEMENT_TYPE>::get(size_t i, size_t j) const {
+inline const ELEMENT_TYPE &Matrix<ELEMENT_TYPE>::get(size_t i, size_t j) const {
     assert(i < shape.rows && j < shape.columns);
     return data[i * shape.columns + j];
 }

--- a/src/include/single_thread_matrix_calculation.h
+++ b/src/include/single_thread_matrix_calculation.h
@@ -71,48 +71,48 @@ bool lessSingleThread(const Matrix<T1> &a,
 // b[sx:sx+shape.rows][sy:sy+shape+shape.columns]
 // NOTE: eps will be used when T1 or T2 is floating number
 template <class T1, class T2>
-inline bool equalSingleThread(const Matrix<T1> &a,
-                              const Matrix<T2> &b,
-                              const size_t &sx,
-                              const size_t &sy,
-                              const Shape &shape,
-                              const double &eps = 1e-100);
+bool equalSingleThread(const Matrix<T1> &a,
+                       const Matrix<T2> &b,
+                       const size_t &sx,
+                       const size_t &sy,
+                       const Shape &shape,
+                       const double &eps = 1e-100);
 
 // Check if the elements of the sub-matrix of a are all less than or equal with the sub-matrix of
 // b's This will only check the a[sx:sx+shape.rows][sy:sy+shape+shape.columns] with
 // b[sx:sx+shape.rows][sy:sy+shape+shape.columns]
 // NOTE: eps will be used when T1 or T2 is floating number
 template <class T1, class T2>
-inline bool lessEqualSingleThread(const Matrix<T1> &a,
-                                  const Matrix<T2> &b,
-                                  const size_t &sx,
-                                  const size_t &sy,
-                                  const Shape &shape,
-                                  const double &eps = 1e-100);
+bool lessEqualSingleThread(const Matrix<T1> &a,
+                           const Matrix<T2> &b,
+                           const size_t &sx,
+                           const size_t &sy,
+                           const Shape &shape,
+                           const double &eps = 1e-100);
 
 // Check if the elements of the sub-matrix of a are all greater than the sub-matrix of b's
 // This will only check the a[sx:sx+shape.rows][sy:sy+shape+shape.columns] with
 // b[sx:sx+shape.rows][sy:sy+shape+shape.columns]
 // NOTE: eps will be used when T1 or T2 is floating number
 template <class T1, class T2>
-inline bool greaterSingleThread(const Matrix<T1> &a,
-                                const Matrix<T2> &b,
-                                const size_t &sx,
-                                const size_t &sy,
-                                const Shape &shape,
-                                const double &eps = 1e-100);
+bool greaterSingleThread(const Matrix<T1> &a,
+                         const Matrix<T2> &b,
+                         const size_t &sx,
+                         const size_t &sy,
+                         const Shape &shape,
+                         const double &eps = 1e-100);
 
 // Check if the elements of the sub-matrix of a are all greater than or equal with the sub-matrix of
 // b's This will only check the a[sx:sx+shape.rows][sy:sy+shape+shape.columns] with
 // b[sx:sx+shape.rows][sy:sy+shape+shape.columns]
 // NOTE: eps will be used when T1 or T2 is floating number
 template <class T1, class T2>
-inline bool greaterEqualSingleThread(const Matrix<T1> &a,
-                                     const Matrix<T2> &b,
-                                     const size_t &sx,
-                                     const size_t &sy,
-                                     const Shape &shape,
-                                     const double &eps = 1e-100);
+bool greaterEqualSingleThread(const Matrix<T1> &a,
+                              const Matrix<T2> &b,
+                              const size_t &sx,
+                              const size_t &sy,
+                              const Shape &shape,
+                              const double &eps = 1e-100);
 
 // Check if any element of the sub-matrix of a is not equal with the sub-matrix of b's
 // This will only check the a[sx:sx+shape.rows][sy:sy+shape+shape.columns] with
@@ -454,12 +454,12 @@ bool lessSingleThread(const Matrix<T1> &a,
 }
 
 template <class T1, class T2>
-inline bool equalSingleThread(const Matrix<T1> &a,
-                              const Matrix<T2> &b,
-                              const size_t &sx,
-                              const size_t &sy,
-                              const Shape &shape,
-                              const double &eps) {
+bool equalSingleThread(const Matrix<T1> &a,
+                       const Matrix<T2> &b,
+                       const size_t &sx,
+                       const size_t &sy,
+                       const Shape &shape,
+                       const double &eps) {
     assert(a.shape == b.shape);
     assert(sx + shape.rows <= a.shape.rows);
     assert(sy + shape.columns <= a.shape.columns);
@@ -481,12 +481,12 @@ inline bool equalSingleThread(const Matrix<T1> &a,
 }
 
 template <class T1, class T2>
-inline bool lessEqualSingleThread(const Matrix<T1> &a,
-                                  const Matrix<T2> &b,
-                                  const size_t &sx,
-                                  const size_t &sy,
-                                  const Shape &shape,
-                                  const double &eps) {
+bool lessEqualSingleThread(const Matrix<T1> &a,
+                           const Matrix<T2> &b,
+                           const size_t &sx,
+                           const size_t &sy,
+                           const Shape &shape,
+                           const double &eps) {
     assert(a.shape == b.shape);
     assert(sx + shape.rows <= a.shape.rows);
     assert(sy + shape.columns <= a.shape.columns);
@@ -507,12 +507,12 @@ inline bool lessEqualSingleThread(const Matrix<T1> &a,
 }
 
 template <class T1, class T2>
-inline bool greaterSingleThread(const Matrix<T1> &a,
-                                const Matrix<T2> &b,
-                                const size_t &sx,
-                                const size_t &sy,
-                                const Shape &shape,
-                                const double &eps) {
+bool greaterSingleThread(const Matrix<T1> &a,
+                         const Matrix<T2> &b,
+                         const size_t &sx,
+                         const size_t &sy,
+                         const Shape &shape,
+                         const double &eps) {
     assert(a.shape == b.shape);
     assert(sx + shape.rows <= a.shape.rows);
     assert(sy + shape.columns <= a.shape.columns);
@@ -536,12 +536,12 @@ inline bool greaterSingleThread(const Matrix<T1> &a,
 }
 
 template <class T1, class T2>
-inline bool greaterEqualSingleThread(const Matrix<T1> &a,
-                                     const Matrix<T2> &b,
-                                     const size_t &sx,
-                                     const size_t &sy,
-                                     const Shape &shape,
-                                     const double &eps) {
+bool greaterEqualSingleThread(const Matrix<T1> &a,
+                              const Matrix<T2> &b,
+                              const size_t &sx,
+                              const size_t &sy,
+                              const Shape &shape,
+                              const double &eps) {
     assert(a.shape == b.shape);
     assert(sx + shape.rows <= a.shape.rows);
     assert(sy + shape.columns <= a.shape.columns);

--- a/src/include/single_thread_matrix_calculation.h
+++ b/src/include/single_thread_matrix_calculation.h
@@ -393,7 +393,7 @@ void numberPowSingleThread(Number &&number,
                            const size_t &sx,
                            const size_t &sy,
                            const Shape &shape) {
-    assert(&a != &output);
+    assert(reinterpret_cast<const void *>(&a) != reinterpret_cast<const void *>(&output));
     assert(a.shape == output.shape);
     assert(sx + shape.rows <= output.shape.rows);
     assert(sy + shape.columns <= output.shape.columns);
@@ -413,7 +413,7 @@ void powNumberSingleThread(const Matrix<T> &a,
                            const size_t &sx,
                            const size_t &sy,
                            const Shape &shape) {
-    assert(&a != &output);
+    assert(reinterpret_cast<const void *>(&a) != reinterpret_cast<const void *>(&output));
     assert(a.shape == output.shape);
     assert(sx + shape.rows <= output.shape.rows);
     assert(sy + shape.columns <= output.shape.columns);
@@ -596,7 +596,7 @@ void multiplySingleThread(const Number &number,
                           const size_t &sx,
                           const size_t &sy,
                           const Shape &shape) {
-    assert(&a != &output);
+    assert(reinterpret_cast<const void *>(&a) != reinterpret_cast<const void *>(&output));
     assert(a.shape == output.shape);
     assert(sx + shape.rows <= output.shape.rows);
     assert(sy + shape.columns <= output.shape.columns);
@@ -616,7 +616,7 @@ void addSingleThread(const Matrix<T1> &a,
                      const size_t &sx,
                      const size_t &sy,
                      const Shape &shape) {
-    assert(&a != &output);
+    assert(reinterpret_cast<const void *>(&a) != reinterpret_cast<const void *>(&output));
     assert(a.shape == b.shape);
     assert(a.shape == output.shape);
     assert(sx + shape.rows <= output.shape.rows);
@@ -637,7 +637,7 @@ void subtractSingleThread(const Matrix<T1> &a,
                           const size_t &sx,
                           const size_t &sy,
                           const Shape &shape) {
-    assert(&a != &output);
+    assert(reinterpret_cast<const void *>(&a) != reinterpret_cast<const void *>(&output));
     assert(a.shape == b.shape);
     assert(sx + shape.rows <= a.shape.rows);
     assert(sy + shape.columns <= a.shape.columns);
@@ -657,7 +657,7 @@ void multiplySingleThread(const Matrix<T1> &a,
                           const size_t &sx,
                           const size_t &sy,
                           const Shape &shape) {
-    assert(&a != &output);
+    assert(reinterpret_cast<const void *>(&a) != reinterpret_cast<const void *>(&output));
     assert(a.shape.columns == b.shape.rows);
     assert(a.shape.rows == output.shape.rows);
     assert(b.shape.columns == output.shape.columns);
@@ -685,7 +685,7 @@ void addSingleThread(const Number &number,
                      const size_t &sx,
                      const size_t &sy,
                      const Shape &shape) {
-    assert(&a != &output);
+    assert(reinterpret_cast<const void *>(&a) != reinterpret_cast<const void *>(&output));
     assert(a.shape == output.shape);
     assert(sx + shape.rows <= output.shape.rows);
     assert(sy + shape.columns <= output.shape.columns);
@@ -705,7 +705,7 @@ void subtractSingleThread(const Number &number,
                           const size_t &sx,
                           const size_t &sy,
                           const Shape &shape) {
-    assert(&a != &output);
+    assert(reinterpret_cast<const void *>(&a) != reinterpret_cast<const void *>(&output));
     assert(a.shape == output.shape);
     assert(sx + shape.rows <= output.shape.rows);
     assert(sy + shape.columns <= output.shape.columns);
@@ -724,7 +724,7 @@ void subtractSingleThread(const Matrix<T> &a,
                           const size_t &sx,
                           const size_t &sy,
                           const Shape &shape) {
-    assert(&a != &output);
+    assert(reinterpret_cast<const void *>(&a) != reinterpret_cast<const void *>(&output));
     assert(a.shape == output.shape);
     assert(sx + shape.rows <= output.shape.rows);
     assert(sy + shape.columns <= output.shape.columns);
@@ -744,7 +744,7 @@ void divideSingleThread(const Matrix<T> &a,
                         const size_t &sx,
                         const size_t &sy,
                         const Shape &shape) {
-    assert(&a != &output);
+    assert(reinterpret_cast<const void *>(&a) != reinterpret_cast<const void *>(&output));
     assert(a.shape == output.shape);
     assert(sx + shape.rows <= output.shape.rows);
     assert(sy + shape.columns <= output.shape.columns);
@@ -764,7 +764,7 @@ void divideSingleThread(const Number &number,
                         const size_t &sx,
                         const size_t &sy,
                         const Shape &shape) {
-    assert(&a != &output);
+    assert(reinterpret_cast<const void *>(&a) != reinterpret_cast<const void *>(&output));
     assert(a.shape == output.shape);
     assert(sx + shape.rows <= output.shape.rows);
     assert(sy + shape.columns <= output.shape.columns);

--- a/src/include/thread_pool.h
+++ b/src/include/thread_pool.h
@@ -16,25 +16,22 @@ namespace mca {
 class ThreadPool {
 public:
     // size is the size of the thread pool
-    ThreadPool(size_t size = 5) { resize(size); }
+    inline ThreadPool(size_t size = 5);
 
     // set a new size
     // this will not clear the taskQueue
     // if the new size is greater than the old one
     // this will not stop the previous threads
-    // otherwise this will wail for all the running threads finish
+    // otherwise this will wait for all the running threads finish
     // and recreate new threads
     void resize(size_t newSize);
 
     // the size of the thread pool
-    size_t size() { return threadQueue.size(); }
+    inline size_t size();
 
     // get the number of unstarted tasks
     // which is the size() of taskQueue
-    size_t getTaskNum() {
-        std::unique_lock<std::mutex> locker{mu};
-        return taskQueue.size();
-    }
+    inline size_t getTaskNum();
 
     // add a task to the thread pool
     // this will return a std::future
@@ -45,10 +42,7 @@ public:
 
     // clear the taskQueue
     // the tasks which are executing will not stop
-    void clearTaskQueue() {
-        std::unique_lock<std::mutex> locker{mu};
-        taskQueue = std::queue<std::function<void()>>();
-    }
+    inline void clearTaskQueue();
 
     // clear taskQueue, and stop all threads
     // if a thread is running
@@ -56,7 +50,7 @@ public:
     void clear();
 
     // the destructor will stop all the threads
-    ~ThreadPool() { clear(); }
+    inline ~ThreadPool();
 
 private:
     std::queue<std::function<void()>> taskQueue;
@@ -77,6 +71,22 @@ auto ThreadPool::addTask(Function &&func, Args &&...args)
     cv.notify_one();
     return taskPtr->get_future();
 }
+
+inline ThreadPool::ThreadPool(size_t size) { resize(size); }
+
+inline size_t ThreadPool::size() { return threadQueue.size(); }
+
+inline size_t ThreadPool::getTaskNum() {
+    std::unique_lock<std::mutex> locker{mu};
+    return taskQueue.size();
+}
+
+inline void ThreadPool::clearTaskQueue() {
+    std::unique_lock<std::mutex> locker{mu};
+    taskQueue = std::queue<std::function<void()>>();
+}
+
+inline ThreadPool::~ThreadPool() { clear(); }
 }  // namespace mca
 
 #endif

--- a/test/src/different_type_test.cpp
+++ b/test/src/different_type_test.cpp
@@ -1,0 +1,156 @@
+#include <gtest/gtest.h>
+
+#include "single_thread_matrix_calculation.h"
+
+namespace mca {
+namespace test {
+class TestDifferentType : public testing::Test {
+protected:
+    Matrix<> doubleMatrix, doubleOutput, doubleResult;
+    Matrix<int> intMatrix, intOutput, intResult;
+
+    void SetUp() override {
+        doubleMatrix = Matrix<>({3, 3}, -1.);
+        doubleOutput = Matrix<>({3, 3}, 0.);
+        intMatrix    = Matrix<int>({3, 3}, -1);
+        intOutput    = Matrix<int>({3, 3}, 0);
+    }
+
+    void TearDown() override {}
+};
+
+TEST_F(TestDifferentType, differentTypeComparison) {
+    ASSERT_TRUE(equalSingleThread(doubleMatrix, intMatrix, 0, 0, doubleMatrix.getShape()));
+    ASSERT_FALSE(notEqualSingleThread(doubleMatrix, intMatrix, 0, 0, doubleMatrix.getShape()));
+    ASSERT_FALSE(lessSingleThread(doubleMatrix, intMatrix, 0, 0, doubleMatrix.getShape()));
+    ASSERT_TRUE(lessEqualSingleThread(doubleMatrix, intMatrix, 0, 0, doubleMatrix.getShape()));
+    ASSERT_FALSE(greaterSingleThread(doubleMatrix, intMatrix, 0, 0, doubleMatrix.getShape()));
+    ASSERT_TRUE(greaterEqualSingleThread(doubleMatrix, intMatrix, 0, 0, doubleMatrix.getShape()));
+}
+
+TEST_F(TestDifferentType, differentTypeCalculation) {
+    addSingleThread(intMatrix, doubleMatrix, doubleOutput, 0, 0, intMatrix.getShape());
+    doubleResult = Matrix<>({3, 3}, -2.);
+    ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, 0, doubleOutput.getShape()));
+    addSingleThread(intMatrix, doubleMatrix, intOutput, 0, 0, intMatrix.getShape());
+    intResult = Matrix<int>({3, 3}, -2);
+    ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, 0, intOutput.getShape()));
+
+    subtractSingleThread(intMatrix, doubleMatrix, doubleOutput, 0, 0, intMatrix.getShape());
+    doubleResult = Matrix<>({3, 3}, 0);
+    ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, 0, doubleOutput.getShape()));
+    subtractSingleThread(intMatrix, doubleMatrix, intOutput, 0, 0, intMatrix.getShape());
+    intResult = Matrix<int>({3, 3}, 0);
+    ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, 0, intOutput.getShape()));
+
+    multiplySingleThread(intMatrix, doubleMatrix, doubleOutput, 0, 0, intMatrix.getShape());
+    doubleResult = Matrix<>({3, 3}, 3.);
+    ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, 0, doubleOutput.getShape()));
+    multiplySingleThread(intMatrix, doubleMatrix, intOutput, 0, 0, intMatrix.getShape());
+    intResult = Matrix<int>({3, 3}, 3);
+    ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, 0, intOutput.getShape()));
+
+    powNumberSingleThread(doubleMatrix, 2, doubleOutput, 0, 0, doubleMatrix.getShape());
+    doubleResult = Matrix<>({3, 3}, 1.);
+    ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, 0, doubleOutput.getShape()));
+    powNumberSingleThread(doubleMatrix, 2, intOutput, 0, 0, doubleMatrix.getShape());
+    intResult = Matrix<int>({3, 3}, 1);
+    ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, 0, intOutput.getShape()));
+    powNumberSingleThread(intMatrix, 2, doubleOutput, 0, 0, intMatrix.getShape());
+    doubleResult = Matrix<>({3, 3}, 1.);
+    ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, 0, doubleOutput.getShape()));
+    powNumberSingleThread(intMatrix, 2, intOutput, 0, 0, intMatrix.getShape());
+    intResult = Matrix<int>({3, 3}, 1);
+    ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, 0, intOutput.getShape()));
+
+    numberPowSingleThread(2, doubleMatrix, doubleOutput, 0, 0, doubleMatrix.getShape());
+    doubleResult = Matrix<>({3, 3}, std::pow(2, -1));
+    ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, 0, doubleOutput.getShape()));
+    numberPowSingleThread(2, doubleMatrix, intOutput, 0, 0, doubleMatrix.getShape());
+    intResult = Matrix<int>({3, 3}, static_cast<int>(std::pow(2, -1)));
+    ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, 0, intOutput.getShape()));
+    numberPowSingleThread(2, intMatrix, doubleOutput, 0, 0, intMatrix.getShape());
+    doubleResult = Matrix<>({3, 3}, std::pow(2, -1));
+    ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, 0, doubleOutput.getShape()));
+    numberPowSingleThread(2, intMatrix, intOutput, 0, 0, intMatrix.getShape());
+    intResult = Matrix<int>({3, 3}, static_cast<int>(std::pow(2, -1)));
+    ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, 0, intOutput.getShape()));
+
+    addSingleThread(1, doubleMatrix, doubleOutput, 0, 0, doubleMatrix.getShape());
+    doubleResult = Matrix<>({3, 3}, 0.);
+    ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, 0, doubleOutput.getShape()));
+    addSingleThread(1, doubleMatrix, intOutput, 0, 0, doubleMatrix.getShape());
+    intResult = Matrix<int>({3, 3}, 0);
+    ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, 0, intOutput.getShape()));
+    addSingleThread(1, intMatrix, doubleOutput, 0, 0, intMatrix.getShape());
+    doubleResult = Matrix<>({3, 3}, 0.);
+    ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, 0, doubleOutput.getShape()));
+    addSingleThread(1, intMatrix, intOutput, 0, 0, intMatrix.getShape());
+    intResult = Matrix<int>({3, 3}, 0);
+    ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, 0, intOutput.getShape()));
+
+    subtractSingleThread(1, doubleMatrix, doubleOutput, 0, 0, doubleMatrix.getShape());
+    doubleResult = Matrix<>({3, 3}, 2.);
+    ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, 0, doubleOutput.getShape()));
+    subtractSingleThread(1, doubleMatrix, intOutput, 0, 0, doubleMatrix.getShape());
+    intResult = Matrix<int>({3, 3}, 2);
+    ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, 0, intOutput.getShape()));
+    subtractSingleThread(1, intMatrix, doubleOutput, 0, 0, intMatrix.getShape());
+    doubleResult = Matrix<>({3, 3}, 2.);
+    ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, 0, doubleOutput.getShape()));
+    subtractSingleThread(1, intMatrix, intOutput, 0, 0, intMatrix.getShape());
+    intResult = Matrix<int>({3, 3}, 2);
+    ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, 0, intOutput.getShape()));
+    subtractSingleThread(doubleMatrix, 1, doubleOutput, 0, 0, doubleMatrix.getShape());
+    doubleResult = Matrix<>({3, 3}, -2.);
+    ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, 0, doubleOutput.getShape()));
+    subtractSingleThread(doubleMatrix, 1, intOutput, 0, 0, doubleMatrix.getShape());
+    intResult = Matrix<int>({3, 3}, -2);
+    ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, 0, intOutput.getShape()));
+    subtractSingleThread(intMatrix, 1, doubleOutput, 0, 0, intMatrix.getShape());
+    doubleResult = Matrix<>({3, 3}, -2.);
+    ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, 0, doubleOutput.getShape()));
+    subtractSingleThread(intMatrix, 1, intOutput, 0, 0, intMatrix.getShape());
+    intResult = Matrix<int>({3, 3}, -2);
+    ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, 0, intOutput.getShape()));
+
+    multiplySingleThread(-1, doubleMatrix, doubleOutput, 0, 0, doubleMatrix.getShape());
+    doubleResult = Matrix<>({3, 3}, 1.);
+    ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, 0, doubleOutput.getShape()));
+    multiplySingleThread(-1, doubleMatrix, intOutput, 0, 0, doubleMatrix.getShape());
+    intResult = Matrix<int>({3, 3}, 1);
+    ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, 0, intOutput.getShape()));
+    multiplySingleThread(-1, intMatrix, doubleOutput, 0, 0, intMatrix.getShape());
+    doubleResult = Matrix<>({3, 3}, 1.);
+    ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, 0, doubleOutput.getShape()));
+    multiplySingleThread(-1, intMatrix, intOutput, 0, 0, intMatrix.getShape());
+    intResult = Matrix<int>({3, 3}, 1);
+    ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, 0, intOutput.getShape()));
+
+    divideSingleThread(-1, doubleMatrix, doubleOutput, 0, 0, doubleMatrix.getShape());
+    doubleResult = Matrix<>({3, 3}, 1.);
+    ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, 0, doubleOutput.getShape()));
+    divideSingleThread(-1, doubleMatrix, intOutput, 0, 0, doubleMatrix.getShape());
+    intResult = Matrix<int>({3, 3}, 1);
+    ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, 0, intOutput.getShape()));
+    divideSingleThread(-1, intMatrix, doubleOutput, 0, 0, intMatrix.getShape());
+    doubleResult = Matrix<>({3, 3}, 1.);
+    ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, 0, doubleOutput.getShape()));
+    divideSingleThread(-1, intMatrix, intOutput, 0, 0, intMatrix.getShape());
+    intResult = Matrix<int>({3, 3}, 1);
+    ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, 0, intOutput.getShape()));
+    divideSingleThread(doubleMatrix, 3, doubleOutput, 0, 0, doubleMatrix.getShape());
+    doubleResult = Matrix<>({3, 3}, -1. / 3);
+    ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, 0, doubleOutput.getShape()));
+    divideSingleThread(doubleMatrix, 3, intOutput, 0, 0, doubleMatrix.getShape());
+    intResult = Matrix<int>({3, 3}, -1. / 3);
+    ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, 0, intOutput.getShape()));
+    divideSingleThread(intMatrix, 3, doubleOutput, 0, 0, intMatrix.getShape());
+    doubleResult = Matrix<>({3, 3}, -1. / 3);
+    ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, 0, doubleOutput.getShape()));
+    divideSingleThread(intMatrix, 3, intOutput, 0, 0, intMatrix.getShape());
+    intResult = Matrix<int>({3, 3}, -1. / 3);
+    ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, 0, intOutput.getShape()));
+}
+}  // namespace test
+}  // namespace mca

--- a/test/src/thread_pool_test.cpp
+++ b/test/src/thread_pool_test.cpp
@@ -10,7 +10,7 @@ TEST(TestThreadPool, defaultConstructor) {
     ASSERT_EQ(tp.getTaskNum(), (size_t)0);
 }
 
-TEST(TestThreadPool, setThreadNum) {
+TEST(TestThreadPool, resize) {
     ThreadPool tp(3);
     ASSERT_EQ(tp.size(), (size_t)3);
     ASSERT_EQ(tp.getTaskNum(), (size_t)0);
@@ -35,6 +35,17 @@ TEST(TestThreadPool, addTask) {
     for (size_t i = 0; i < taskNum; i++) {
         ASSERT_EQ(resultVector[i].get(), (size_t)2 + (size_t)3);
     }
+}
+
+TEST(TestThreadPool, clearTaskQueue) {
+    ThreadPool tp(0);
+    size_t taskNum = 10;
+    for (size_t i = 0; i < taskNum; i++) {
+        tp.addTask([]() {});
+    }
+    ASSERT_EQ(tp.getTaskNum(), taskNum);
+    tp.clearTaskQueue();
+    ASSERT_EQ(tp.getTaskNum(), 0);
 }
 
 // this test will check if the running task will be executed normally


### PR DESCRIPTION
In `clang-tidy`, we define a rule that can not compare two pointers which have different types. When matrix `a` and matrix `output` have different types, the `clang-tidy` will give an error (because we use `assert(&a != &output)` to let the developers know the `a` and the `output` should not be the same). And this error will now occur in the `git action`, because the `git action` will build the `release` version, the `assert` is removed by compiler. Now we use `reinterpret_cast<const void *>` to convert them to `const void *`. Besides, we add some simple tests for matrix whose types are different.

See #46 .