### PR TITLE
Modify the sing thread calulation and test

### DIFF
--- a/src/include/matrix.h
+++ b/src/include/matrix.h
@@ -295,27 +295,27 @@ private:
     //                                   const size_t &sy,
     //                                   const Shape &shape,
     //                                   const double &eps);
-    template <class T1, class T2>
-    friend bool lessSingleThread(const Matrix<T1> &a,
-                                 const Matrix<T2> &b,
-                                 const size_t &sx,
-                                 const size_t &sy,
-                                 const Shape &shape,
-                                 const double &eps);
-    template <class T1, class T2>
-    friend bool lessEqualSingleThread(const Matrix<T1> &a,
-                                      const Matrix<T2> &b,
-                                      const size_t &sx,
-                                      const size_t &sy,
-                                      const Shape &shape,
-                                      const double &eps);
-    template <class T1, class T2>
-    friend bool greaterSingleThread(const Matrix<T1> &a,
-                                    const Matrix<T2> &b,
-                                    const size_t &sx,
-                                    const size_t &sy,
-                                    const Shape &shape,
-                                    const double &eps);
+    //     template <class T1, class T2>
+    //     friend bool lessSingleThread(const Matrix<T1> &a,
+    //                                  const Matrix<T2> &b,
+    //                                  const size_t &sx,
+    //                                  const size_t &sy,
+    //                                  const Shape &shape,
+    //                                  const double &eps);
+    //     template <class T1, class T2>
+    //     friend bool lessEqualSingleThread(const Matrix<T1> &a,
+    //                                       const Matrix<T2> &b,
+    //                                       const size_t &sx,
+    //                                       const size_t &sy,
+    //                                       const Shape &shape,
+    //                                       const double &eps);
+    //     template <class T1, class T2>
+    //     friend bool greaterSingleThread(const Matrix<T1> &a,
+    //                                     const Matrix<T2> &b,
+    //                                     const size_t &sx,
+    //                                     const size_t &sy,
+    //                                     const Shape &shape,
+    //                                     const double &eps);
     template <class T1, class T2>
     friend bool greaterEqualSingleThread(const Matrix<T1> &a,
                                          const Matrix<T2> &b,
@@ -396,20 +396,20 @@ private:
     //                                    const size_t &sy,
     //                                    const Shape &shape);
 
-    template <class Number, class T, class O>
-    friend void numberPowSingleThread(Number &&number,
-                                      const Matrix<T> &a,
-                                      Matrix<O> &output,
-                                      const size_t &sx,
-                                      const size_t &sy,
-                                      const Shape &shape);
-    template <class T, class Number, class O>
-    friend void powNumberSingleThread(const Matrix<T> &a,
-                                      Number &&number,
-                                      Matrix<O> &output,
-                                      const size_t &sx,
-                                      const size_t &sy,
-                                      const Shape &shape);
+    //     template <class Number, class T, class O>
+    //     friend void numberPowSingleThread(Number &&number,
+    //                                       const Matrix<T> &a,
+    //                                       Matrix<O> &output,
+    //                                       const size_t &sx,
+    //                                       const size_t &sy,
+    //                                       const Shape &shape);
+    //     template <class T, class Number, class O>
+    //     friend void powNumberSingleThread(const Matrix<T> &a,
+    //                                       Number &&number,
+    //                                       Matrix<O> &output,
+    //                                       const size_t &sx,
+    //                                       const size_t &sy,
+    //                                       const Shape &shape);
 
     // template <class T>
     // friend void transposeSingleThread(const Matrix<T> &a,

--- a/src/include/single_thread_matrix_calculation.h
+++ b/src/include/single_thread_matrix_calculation.h
@@ -9,61 +9,57 @@
 namespace mca {
 
 // Calculate number ^ a, and store the result in output
-// This will only calculate the number^a[sx:sx+shape.rows][sy:sy+shape+shape.columns]
-// sx: start row
-// sy: start column
-// shape: the shape of matrix will be calculated
+// This will only calculate the number^a[pos: pos + len] in the matrix
+// pos: one-demensional starting index of the matrix
+// len: number of elements to be calculated
 // NOTE: a must have the same shape with output
 //       &a must not be equal with &output
 //       the matrix which will be calculated must in range
 // for example: number = 2,
 //              a = [[1, 2, 3],
 //                   [2, 3, 4]]
-//              sx = 0, sy = 1
-//              shape = {2, 2}
+//              pos = 1
+//              len = 4
 //              output = [[origin, 2^2, 2^3],
-//                        [origin, 2^3, 2^4]]
+//                        [2^2, 2^3, origin]]
 template <class Number, class T, class O>
 void numberPowSingleThread(Number &&number,
                            const Matrix<T> &a,
                            Matrix<O> &output,
-                           const size_t &sx,
-                           const size_t &sy,
-                           const Shape &shape);
+                           const size_t &pos,
+                           const size_t &len);
 
 // Calculate a ^ number, and store the result in output
-// This will only calculate the a^number[sx:sx+shape.rows][sy:sy+shape+shape.columns]
-// sx: start row
-// sy: start column
-// shape: the shape of matrix will be calculated
+// This will only calculate the a^number[pos: pos + len] in the matrix
+// pos: one-demensional starting index of the matrix
+// len: number of elements to be calculated
 // NOTE: a must have the same shape with output
 //       &a must not be equal with &output
 //       the matrix which will be calculated must in range
 // for example: number = 2,
 //              a = [[1, 2, 3],
 //                   [2, 3, 4]]
-//              sx = 0, sy = 1
-//              shape = {2, 2}
+//              pos = 1
+//              len = 4
 //              output = [[origin, 2^2, 3^2],
-//                        [origin, 3^2, 4^2]]
+//                        [2^2, 3^2, origin]]
 template <class T, class Number, class O>
 void powNumberSingleThread(const Matrix<T> &a,
                            Number &&number,
                            Matrix<O> &output,
-                           const size_t &sx,
-                           const size_t &sy,
-                           const Shape &shape);
+                           const size_t &pos,
+                           const size_t &len);
 
 // Check if the elements of the sub-matrix of a are all less than the sub-matrix of b's
-// This will only check the a[sx:sx+shape.rows][sy:sy+shape+shape.columns] with
-// b[sx:sx+shape.rows][sy:sy+shape+shape.columns]
+// This will only check the a[pos:pos+len] with b[pos:pos+len]
+// pos: one-demensional starting index of the matrix
+// len: number of elements to be checked
 // NOTE: eps will be used when T1 or T2 is floating number
 template <class T1, class T2>
 bool lessSingleThread(const Matrix<T1> &a,
                       const Matrix<T2> &b,
-                      const size_t &sx,
-                      const size_t &sy,
-                      const Shape &shape,
+                      const size_t &pos,
+                      const size_t &len,
                       const double &eps = 1e-100);
 
 // Check if the elements of the sub-matrix of a are all equal with the sub-matrix of b's
@@ -77,27 +73,27 @@ bool equalSingleThread(const Matrix<T1> &a,
                        const double &eps = 1e-100);
 
 // Check if the elements of the sub-matrix of a are all less than or equal with the sub-matrix of
-// b's This will only check the a[sx:sx+shape.rows][sy:sy+shape+shape.columns] with
-// b[sx:sx+shape.rows][sy:sy+shape+shape.columns]
+// This will only check the a[pos:pos+len] with b[pos:pos+len]
+// pos: one-demensional starting index of the matrix
+// len: number of elements to be checked
 // NOTE: eps will be used when T1 or T2 is floating number
 template <class T1, class T2>
 bool lessEqualSingleThread(const Matrix<T1> &a,
                            const Matrix<T2> &b,
-                           const size_t &sx,
-                           const size_t &sy,
-                           const Shape &shape,
+                           const size_t &pos,
+                           const size_t &len,
                            const double &eps = 1e-100);
 
 // Check if the elements of the sub-matrix of a are all greater than the sub-matrix of b's
-// This will only check the a[sx:sx+shape.rows][sy:sy+shape+shape.columns] with
-// b[sx:sx+shape.rows][sy:sy+shape+shape.columns]
+// This will only check the a[pos:pos+len] with b[pos:pos+len]
+// pos: one-demensional starting index of the matrix
+// len: number of elements to be checked
 // NOTE: eps will be used when T1 or T2 is floating number
 template <class T1, class T2>
 bool greaterSingleThread(const Matrix<T1> &a,
                          const Matrix<T2> &b,
-                         const size_t &sx,
-                         const size_t &sy,
-                         const Shape &shape,
+                         const size_t &pos,
+                         const size_t &len,
                          const double &eps = 1e-100);
 
 // Check if the elements of the sub-matrix of a are all greater than or equal with the sub-matrix of
@@ -384,19 +380,15 @@ template <class Number, class T, class O>
 void numberPowSingleThread(Number &&number,
                            const Matrix<T> &a,
                            Matrix<O> &output,
-                           const size_t &sx,
-                           const size_t &sy,
-                           const Shape &shape) {
+                           const size_t &pos,
+                           const size_t &len) {
     assert(reinterpret_cast<const void *>(&a) != reinterpret_cast<const void *>(&output));
     assert(a.shape() == output.shape());
-    assert(sx + shape.rows <= output.rows());
-    assert(sy + shape.columns <= output.columns());
+    assert(pos + len <= a.size());
     using CommonType = std::common_type_t<Number, T, O>;
-    for (size_t i = sx; i < sx + shape.rows; i++) {
-        for (size_t j = sy; j < sy + shape.columns; j++) {
-            output.get(i, j) = static_cast<O>(
-                std::pow(static_cast<CommonType>(number), static_cast<CommonType>(a.get(i, j))));
-        }
+    for (size_t i = pos; i < pos + len; i++) {
+        output.dataPtr()[i] = static_cast<O>(
+            std::pow(static_cast<CommonType>(number), static_cast<CommonType>(a.dataPtr()[i])));
     }
 }
 
@@ -404,44 +396,36 @@ template <class T, class Number, class O>
 void powNumberSingleThread(const Matrix<T> &a,
                            Number &&number,
                            Matrix<O> &output,
-                           const size_t &sx,
-                           const size_t &sy,
-                           const Shape &shape) {
+                           const size_t &pos,
+                           const size_t &len) {
     assert(reinterpret_cast<const void *>(&a) != reinterpret_cast<const void *>(&output));
     assert(a.shape() == output.shape());
-    assert(sx + shape.rows <= output.rows());
-    assert(sy + shape.columns <= output.columns());
+    assert(pos + len <= a.size());
     using CommonType = std::common_type_t<Number, T, O>;
-    for (size_t i = sx; i < sx + shape.rows; i++) {
-        for (size_t j = sy; j < sy + shape.columns; j++) {
-            output.get(i, j) = static_cast<O>(
-                std::pow(static_cast<CommonType>(a.get(i, j)), static_cast<CommonType>(number)));
-        }
+    for (size_t i = pos; i < pos + len; i++) {
+        output.dataPtr()[i] = static_cast<O>(
+            std::pow(static_cast<CommonType>(a.dataPtr()[i]), static_cast<CommonType>(number)));
     }
 }
 
 template <class T1, class T2>
 bool lessSingleThread(const Matrix<T1> &a,
                       const Matrix<T2> &b,
-                      const size_t &sx,
-                      const size_t &sy,
-                      const Shape &shape,
+                      const size_t &pos,
+                      const size_t &len,
                       const double &eps) {
     assert(a.shape() == b.shape());
-    assert(sx + shape.rows <= a.rows());
-    assert(sy + shape.columns <= a.columns());
+    assert(pos + len <= a.size());
     using CommonType = std::common_type_t<T1, T2>;
-    for (size_t i = sx; i < sx + shape.rows; i++) {
-        for (size_t j = sy; j < sy + shape.columns; j++) {
-            if (std::is_floating_point_v<CommonType> &&
-                static_cast<CommonType>(a.get(i, j)) - static_cast<CommonType>(b.get(i, j)) >=
-                    -eps) {
-                return false;
-            }
-            if (!std::is_floating_point_v<CommonType> &&
-                static_cast<CommonType>(a.get(i, j)) >= static_cast<CommonType>(b.get(i, j))) {
-                return false;
-            }
+    for (size_t i = pos; i < pos + len; i++) {
+        if (std::is_floating_point_v<CommonType> &&
+            static_cast<CommonType>(a.dataPtr()[i]) - static_cast<CommonType>(b.dataPtr()[i]) >=
+                -eps) {
+            return false;
+        }
+        if (!std::is_floating_point_v<CommonType> &&
+            (static_cast<CommonType>(a.dataPtr()[i]) >= static_cast<CommonType>(b.dataPtr()[i]))) {
+            return false;
         }
     }
     return true;
@@ -476,24 +460,21 @@ bool equalSingleThread(const Matrix<T1> &a,
 template <class T1, class T2>
 bool lessEqualSingleThread(const Matrix<T1> &a,
                            const Matrix<T2> &b,
-                           const size_t &sx,
-                           const size_t &sy,
-                           const Shape &shape,
+                           const size_t &pos,
+                           const size_t &len,
                            const double &eps) {
     assert(a.shape() == b.shape());
-    assert(sx + shape.rows <= a.rows());
-    assert(sy + shape.columns <= a.columns());
+    assert(pos + len <= a.size());
     using CommonType = std::common_type_t<T1, T2>;
-    for (size_t i = sx; i < sx + shape.rows; i++) {
-        for (size_t j = sy; j < sy + shape.columns; j++) {
-            if (std::is_floating_point_v<CommonType> &&
-                static_cast<CommonType>(a.get(i, j)) - static_cast<CommonType>(b.get(i, j)) > eps) {
-                return false;
-            }
-            if (!std::is_floating_point_v<CommonType> &&
-                static_cast<CommonType>(a.get(i, j)) > static_cast<CommonType>(b.get(i, j))) {
-                return false;
-            }
+    for (size_t i = pos; i < pos + len; i++) {
+        if (std::is_floating_point_v<CommonType> &&
+            static_cast<CommonType>(a.dataPtr()[i]) - static_cast<CommonType>(b.dataPtr()[i]) >
+                eps) {
+            return false;
+        }
+        if (!std::is_floating_point_v<CommonType> &&
+            static_cast<CommonType>(a.dataPtr()[i]) > static_cast<CommonType>(b.dataPtr()[i])) {
+            return false;
         }
     }
     return true;
@@ -502,27 +483,23 @@ bool lessEqualSingleThread(const Matrix<T1> &a,
 template <class T1, class T2>
 bool greaterSingleThread(const Matrix<T1> &a,
                          const Matrix<T2> &b,
-                         const size_t &sx,
-                         const size_t &sy,
-                         const Shape &shape,
+                         const size_t &pos,
+                         const size_t &len,
                          const double &eps) {
     assert(a.shape() == b.shape());
-    assert(sx + shape.rows <= a.rows());
-    assert(sy + shape.columns <= a.columns());
+    assert(pos + len <= a.size());
     using CommonType = std::common_type_t<T1, T2>;
-    for (size_t i = sx; i < sx + shape.rows; i++) {
-        for (size_t j = sy; j < sy + shape.columns; j++) {
-            if (std::is_floating_point_v<CommonType> &&
-                (static_cast<CommonType>(a.get(i, j)) - static_cast<CommonType>(b.get(i, j)) <
-                     eps ||
-                 fabs(static_cast<CommonType>(a.get(i, j)) -
-                      static_cast<CommonType>(b.get(i, j))) <= eps)) {
-                return false;
-            }
-            if (!std::is_floating_point_v<CommonType> &&
-                static_cast<CommonType>(a.get(i, j)) <= static_cast<CommonType>(b.get(i, j))) {
-                return false;
-            }
+    for (size_t i = pos; i < pos + len; i++) {
+        if (std::is_floating_point_v<CommonType> &&
+            (static_cast<CommonType>(a.dataPtr()[i]) - static_cast<CommonType>(b.dataPtr()[i]) <
+                 eps ||
+             fabs(static_cast<CommonType>(a.dataPtr()[i]) -
+                  static_cast<CommonType>(b.dataPtr()[i])) <= eps)) {
+            return false;
+        }
+        if (!std::is_floating_point_v<CommonType> &&
+            static_cast<CommonType>(a.dataPtr()[i]) <= static_cast<CommonType>(b.dataPtr()[i])) {
+            return false;
         }
     }
     return true;

--- a/src/include/single_thread_matrix_calculation.h
+++ b/src/include/single_thread_matrix_calculation.h
@@ -9,7 +9,7 @@
 namespace mca {
 
 // Calculate number ^ a, and store the result in output
-// This will only calculate the number^a[pos: pos + len] in the matrix
+// This will only calculate the number^a[pos:pos+len] in the matrix
 // pos: one-demensional starting index of the matrix
 // len: number of elements to be calculated
 // NOTE: a must have the same shape with output
@@ -21,7 +21,7 @@ namespace mca {
 //              pos = 1
 //              len = 4
 //              output = [[origin, 2^2, 2^3],
-//                        [2^2, 2^3, origin]]
+//                        [2^2,    2^3, origin]]
 template <class Number, class T, class O>
 void numberPowSingleThread(Number &&number,
                            const Matrix<T> &a,
@@ -42,7 +42,7 @@ void numberPowSingleThread(Number &&number,
 //              pos = 1
 //              len = 4
 //              output = [[origin, 2^2, 3^2],
-//                        [2^2, 3^2, origin]]
+//                        [2^2,    3^2, origin]]
 template <class T, class Number, class O>
 void powNumberSingleThread(const Matrix<T> &a,
                            Number &&number,

--- a/test/src/different_type_test.cpp
+++ b/test/src/different_type_test.cpp
@@ -22,9 +22,9 @@ protected:
 TEST_F(TestDifferentType, differentTypeComparison) {
     ASSERT_TRUE(equalSingleThread(doubleMatrix, intMatrix, 0, doubleMatrix.size()));
     ASSERT_FALSE(notEqualSingleThread(doubleMatrix, intMatrix, 0, 0, doubleMatrix.shape()));
-    ASSERT_FALSE(lessSingleThread(doubleMatrix, intMatrix, 0, 0, doubleMatrix.shape()));
-    ASSERT_TRUE(lessEqualSingleThread(doubleMatrix, intMatrix, 0, 0, doubleMatrix.shape()));
-    ASSERT_FALSE(greaterSingleThread(doubleMatrix, intMatrix, 0, 0, doubleMatrix.shape()));
+    ASSERT_FALSE(lessSingleThread(doubleMatrix, intMatrix, 0, doubleMatrix.size()));
+    ASSERT_TRUE(lessEqualSingleThread(doubleMatrix, intMatrix, 0, doubleMatrix.size()));
+    ASSERT_FALSE(greaterSingleThread(doubleMatrix, intMatrix, 0, doubleMatrix.size()));
     ASSERT_TRUE(greaterEqualSingleThread(doubleMatrix, intMatrix, 0, 0, doubleMatrix.shape()));
 }
 
@@ -50,29 +50,29 @@ TEST_F(TestDifferentType, differentTypeCalculation) {
     intResult = Matrix<int>({3, 3}, 3);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
 
-    powNumberSingleThread(doubleMatrix, 2, doubleOutput, 0, 0, doubleMatrix.shape());
+    powNumberSingleThread(doubleMatrix, 2, doubleOutput, 0, doubleMatrix.size());
     doubleResult = Matrix<>({3, 3}, 1.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
-    powNumberSingleThread(doubleMatrix, 2, intOutput, 0, 0, doubleMatrix.shape());
+    powNumberSingleThread(doubleMatrix, 2, intOutput, 0, doubleMatrix.size());
     intResult = Matrix<int>({3, 3}, 1);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
-    powNumberSingleThread(intMatrix, 2, doubleOutput, 0, 0, intMatrix.shape());
+    powNumberSingleThread(intMatrix, 2, doubleOutput, 0, intMatrix.size());
     doubleResult = Matrix<>({3, 3}, 1.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
-    powNumberSingleThread(intMatrix, 2, intOutput, 0, 0, intMatrix.shape());
+    powNumberSingleThread(intMatrix, 2, intOutput, 0, intMatrix.size());
     intResult = Matrix<int>({3, 3}, 1);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
 
-    numberPowSingleThread(2, doubleMatrix, doubleOutput, 0, 0, doubleMatrix.shape());
+    numberPowSingleThread(2, doubleMatrix, doubleOutput, 0, doubleMatrix.size());
     doubleResult = Matrix<>({3, 3}, std::pow(2, -1));
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
-    numberPowSingleThread(2, doubleMatrix, intOutput, 0, 0, doubleMatrix.shape());
+    numberPowSingleThread(2, doubleMatrix, intOutput, 0, doubleMatrix.size());
     intResult = Matrix<int>({3, 3}, static_cast<int>(std::pow(2, -1)));
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
-    numberPowSingleThread(2, intMatrix, doubleOutput, 0, 0, intMatrix.shape());
+    numberPowSingleThread(2, intMatrix, doubleOutput, 0, intMatrix.size());
     doubleResult = Matrix<>({3, 3}, std::pow(2, -1));
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
-    numberPowSingleThread(2, intMatrix, intOutput, 0, 0, intMatrix.shape());
+    numberPowSingleThread(2, intMatrix, intOutput, 0, intMatrix.size());
     intResult = Matrix<int>({3, 3}, static_cast<int>(std::pow(2, -1)));
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
 

--- a/test/src/single_thread_matrix_calculation_test.cpp
+++ b/test/src/single_thread_matrix_calculation_test.cpp
@@ -30,40 +30,40 @@ protected:
 
 TEST_F(TestSinglThreadCalculation, powNumberWholeMatrix) {
     output = Matrix<>({3, 3}, 0);
-    powNumberSingleThread(a, 2, output, 0, 0, a.shape());
+    powNumberSingleThread(a, 2, output, 0, a.size());
     Matrix<> result = Matrix<>({{0, 0, 0}, {1, 1, 1}, {4, 4, 4}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSinglThreadCalculation, powNumberSubMatrix) {
     output = Matrix<>({3, 3}, -1);
-    powNumberSingleThread(c, 2, output, 0, 1, {2, 2});
-    Matrix<> result = Matrix<>({{-1, 4, 9}, {-1, 25, 36}, {-1, -1, -1}});
+    powNumberSingleThread(c, 2, output, 1, 5);
+    Matrix<> result = Matrix<>({{-1, 4, 9}, {16, 25, 36}, {-1, -1, -1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSinglThreadCalculation, numberPowWholeMatrix) {
     output = Matrix<>({3, 3}, 0);
-    numberPowSingleThread(2, a, output, 0, 0, a.shape());
+    numberPowSingleThread(2, a, output, 0, a.size());
     Matrix<> result = Matrix<>({{1, 1, 1}, {2, 2, 2}, {4, 4, 4}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSinglThreadCalculation, numberPowSubMatrix) {
     output = Matrix<>({3, 3}, -1);
-    numberPowSingleThread(2, c, output, 0, 1, {2, 2});
-    Matrix<> result({{-1, 4, 8}, {-1, 32, 64}, {-1, -1, -1}});
+    numberPowSingleThread(2, c, output, 1, 5);
+    Matrix<> result({{-1, 4, 8}, {16, 32, 64}, {-1, -1, -1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSinglThreadCalculation, lessWholeMatrix) {
-    ASSERT_TRUE(lessSingleThread(a, c, 0, 0, a.shape()));
-    ASSERT_FALSE(lessSingleThread(a, b, 0, 0, a.shape()));
+    ASSERT_TRUE(lessSingleThread(a, c, 0, a.size()));
+    ASSERT_FALSE(lessSingleThread(a, b, 0, a.size()));
 }
 
 TEST_F(TestSinglThreadCalculation, lessSubMatrix) {
-    ASSERT_TRUE(lessSingleThread(a, c, 1, 0, {2, 3}));
-    ASSERT_FALSE(lessSingleThread(a, b, 1, 0, {2, 2}));
+    ASSERT_TRUE(lessSingleThread(a, c, 1, 3));
+    ASSERT_FALSE(lessSingleThread(a, b, 3, 3));
 }
 
 TEST_F(TestSinglThreadCalculation, equalWholeMatrix) {
@@ -77,27 +77,27 @@ TEST_F(TestSinglThreadCalculation, equalSubMatrix) {
 }
 
 TEST_F(TestSinglThreadCalculation, lessEqualWholeMatrix) {
-    ASSERT_TRUE(lessEqualSingleThread(a, c, 0, 0, a.shape()));
-    ASSERT_TRUE(lessEqualSingleThread(a, d, 0, 0, a.shape()));
-    ASSERT_FALSE(lessEqualSingleThread(c, b, 0, 0, a.shape()));
+    ASSERT_TRUE(lessEqualSingleThread(a, c, 0, a.size()));
+    ASSERT_TRUE(lessEqualSingleThread(a, d, 0, a.size()));
+    ASSERT_FALSE(lessEqualSingleThread(c, b, 0, c.size()));
 }
 
 TEST_F(TestSinglThreadCalculation, lessEqualSubMatrix) {
-    ASSERT_TRUE(lessEqualSingleThread(a, c, 0, 0, {2, 3}));
-    ASSERT_TRUE(lessEqualSingleThread(a, d, 0, 0, {2, 3}));
-    ASSERT_FALSE(lessEqualSingleThread(c, a, 0, 0, {2, 3}));
+    ASSERT_TRUE(lessEqualSingleThread(a, c, 4, 4));
+    ASSERT_TRUE(lessEqualSingleThread(a, d, 4, 4));
+    ASSERT_FALSE(lessEqualSingleThread(c, a, 4, 4));
 }
 
 TEST_F(TestSinglThreadCalculation, greaterWholeMatrix) {
-    ASSERT_TRUE(greaterSingleThread(c, a, 0, 0, c.shape()));
-    ASSERT_FALSE(greaterSingleThread(d, a, 0, 0, d.shape()));
-    ASSERT_FALSE(greaterSingleThread(d, b, 0, 0, b.shape()));
+    ASSERT_TRUE(greaterSingleThread(c, a, 0, c.size()));
+    ASSERT_FALSE(greaterSingleThread(d, a, 0, d.size()));
+    ASSERT_FALSE(greaterSingleThread(d, b, 0, d.size()));
 }
 
 TEST_F(TestSinglThreadCalculation, greaterSubMatrix) {
-    ASSERT_TRUE(greaterSingleThread(c, a, 0, 1, {2, 2}));
-    ASSERT_FALSE(greaterSingleThread(a, b, 0, 1, {2, 2}));
-    ASSERT_FALSE(greaterSingleThread(a, d, 0, 1, {2, 2}));
+    ASSERT_TRUE(greaterSingleThread(c, a, 2, 3));
+    ASSERT_FALSE(greaterSingleThread(a, b, 2, 3));
+    ASSERT_FALSE(greaterSingleThread(a, d, 2, 3));
 }
 
 TEST_F(TestSinglThreadCalculation, greaterEqualWholeMatrix) {


### PR DESCRIPTION
We find use `pos` and `len` can better implement multi-thread version, so that we updated these.

see #54.
