### PR TITLE
Add tests for same address

### DIFF
--- a/src/include/matrix.h
+++ b/src/include/matrix.h
@@ -151,7 +151,7 @@ public:
     //              a: [[2^1, 2^2, 2^3],
     //                  [2^2, 2^3, 2^4]]
     template <class Number, class O>
-    void numberPow(const Number &number, Matrix<O> &output);
+    void numberPow(const Number &number, Matrix<O> &output) const;
     template <class Number>
     void numberPow(const Number &number);
 
@@ -170,7 +170,7 @@ public:
     //              a: [[1^2, 2^2, 3^2],
     //                  [2^2, 3^2, 4^2]]
     template <class Number, class O>
-    void powNumber(const Number &number, Matrix<O> &output);
+    void powNumber(const Number &number, Matrix<O> &output) const;
     template <class Number>
     inline void powNumber(const Number &number);
 
@@ -190,7 +190,7 @@ public:
     //              output = [[5, 8],
     //                        [8, 13]]
     template <class O>
-    void pow(size_t exponent, Matrix<O> &output);
+    void pow(size_t exponent, Matrix<O> &output) const;
     void pow(size_t exponent);
 
     // Transpose (*this), and store the result in output
@@ -210,14 +210,14 @@ public:
     //                  [2, 3],
     //                  [3, 4]]
     template <class O>
-    void transpose(Matrix<O> &output);
+    void transpose(Matrix<O> &output) const;
     void transpose();
 
     // Check if the matrix is symmetric with multi-thread
-    bool symmetric();
+    bool symmetric() const;
 
     // Check if the matrix is antisymmetric with multi-thread
-    bool antisymmetric();
+    bool antisymmetric() const;
 
 private:
     std::unique_ptr<ELEMENT_TYPE[]> data;
@@ -650,14 +650,14 @@ void Matrix<ELEMENT_TYPE>::fill(const ELEMENT_TYPE &value, const size_t &pos) {
 // TODO
 template <class ELEMENT_TYPE>
 template <class Number, class O>
-void Matrix<ELEMENT_TYPE>::numberPow(const Number &number, Matrix<O> &output) {}
+void Matrix<ELEMENT_TYPE>::numberPow(const Number &number, Matrix<O> &output) const {}
 template <class ELEMENT_TYPE>
 template <class Number>
 void Matrix<ELEMENT_TYPE>::numberPow(const Number &number) {}
 
 template <class ELEMENT_TYPE>
 template <class Number, class O>
-void Matrix<ELEMENT_TYPE>::powNumber(const Number &number, Matrix<O> &output) {
+void Matrix<ELEMENT_TYPE>::powNumber(const Number &number, Matrix<O> &output) const {
     // single mode
     if (threadNum() == 0 || limit() > size()) {
         powNumberSingleThread(*this, number, output, 0, size());
@@ -695,14 +695,14 @@ inline void Matrix<ELEMENT_TYPE>::powNumber(const Number &number) {
 // TODO
 template <class ELEMENT_TYPE>
 template <class O>
-void Matrix<ELEMENT_TYPE>::pow(size_t exponent, Matrix<O> &output) {}
+void Matrix<ELEMENT_TYPE>::pow(size_t exponent, Matrix<O> &output) const {}
 template <class ELEMENT_TYPE>
 void Matrix<ELEMENT_TYPE>::pow(size_t exponent) {}
 
 // TODO
 template <class ELEMENT_TYPE>
 template <class O>
-void Matrix<ELEMENT_TYPE>::transpose(Matrix<O> &output) {}
+void Matrix<ELEMENT_TYPE>::transpose(Matrix<O> &output) const {}
 template <class ELEMENT_TYPE>
 void Matrix<ELEMENT_TYPE>::transpose() {}
 

--- a/src/include/single_thread_matrix_calculation.h
+++ b/src/include/single_thread_matrix_calculation.h
@@ -293,6 +293,7 @@ void divideSingleThread(const Number &number,
 // len: length of elements
 // NOTE: a must have the same shape with output after transposition
 //       the matrix which will be calculated must in range
+//       &a must not be equal with &output
 // for example: number = 2,
 //              a = [[1, 2, 3],
 //                   [2, 3, 4]]
@@ -677,6 +678,7 @@ void transposeSingleThread(const Matrix<T> &a,
                            Matrix<T> &output,
                            const size_t &pos,
                            const size_t &len) {
+    assert(reinterpret_cast<const void *>(&a) != reinterpret_cast<const void *>(&output));
     assert(a.rows() == output.columns());
     assert(a.columns() == output.rows());
     assert(pos + len <= output.size());

--- a/test/src/same_address_test.cpp
+++ b/test/src/same_address_test.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <cmath>
+
 #include "matrix.h"
 #include "single_thread_matrix_calculation.h"
 
@@ -7,8 +9,11 @@ namespace mca {
 namespace test {
 class TestSameAddress : public testing::Test {
 protected:
-    Matrix<> a;
-    void SetUp() override { a = Matrix<>({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}); }
+    Matrix<> a, b;
+    void SetUp() override {
+        a = Matrix<>({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}});
+        b = a;
+    }
 
     void TearDown() override {}
 };
@@ -19,18 +24,56 @@ TEST_F(TestSameAddress, powNumber) {
     ASSERT_TRUE(equalSingleThread(a, result, 0, a.size()));
 }
 
-TEST_F(TestSameAddress, numberPow) {}
+TEST_F(TestSameAddress, numberPow) {
+    numberPowSingleThread(2, a, a, 0, a.size());
+    Matrix<> result = {{std::pow(2, 1), std::pow(2, 2), std::pow(2, 3)},
+                       {std::pow(2, 4), std::pow(2, 5), std::pow(2, 6)},
+                       {std::pow(2, 7), std::pow(2, 8), std::pow(2, 9)}};
+    ASSERT_TRUE(equalSingleThread(a, result, 0, a.size()));
+}
 
-TEST_F(TestSameAddress, addNumber) {}
+TEST_F(TestSameAddress, addNumber) {
+    addSingleThread(2, a, a, 0, a.size());
+    Matrix<> result = {{2 + 1, 2 + 2, 2 + 3}, {2 + 4, 2 + 5, 2 + 6}, {2 + 7, 2 + 8, 2 + 9}};
+    ASSERT_TRUE(equalSingleThread(a, result, 0, a.size()));
+}
 
-TEST_F(TestSameAddress, subtractNumber) {}
+TEST_F(TestSameAddress, subtractNumber) {
+    subtractSingleThread(a, 2, a, 0, a.size());
+    Matrix<> result1 = {{1 - 2, 2 - 2, 3 - 2}, {4 - 2, 5 - 2, 6 - 2}, {7 - 2, 8 - 2, 9 - 2}};
+    subtractSingleThread(2, b, b, 0, b.size());
+    Matrix<> result2 = {{2 - 1, 2 - 2, 2 - 3}, {2 - 4, 2 - 5, 2 - 6}, {2 - 7, 2 - 8, 2 - 9}};
+    ASSERT_TRUE(equalSingleThread(a, result1, 0, a.size()));
+    ASSERT_TRUE(equalSingleThread(b, result2, 0, b.size()));
+}
 
-TEST_F(TestSameAddress, multiplyNumber) {}
+TEST_F(TestSameAddress, multiplyNumber) {
+    multiplySingleThread(2, a, a, 0, a.size());
+    Matrix<> result = {{2 * 1, 2 * 2, 2 * 3}, {2 * 4, 2 * 5, 2 * 6}, {2 * 7, 2 * 8, 2 * 9}};
+    ASSERT_TRUE(equalSingleThread(a, result, 0, a.size()));
+}
 
-TEST_F(TestSameAddress, divideNumber) {}
+TEST_F(TestSameAddress, divideNumber) {
+    divideSingleThread(a, 2, a, 0, a.size());
+    Matrix<> result1 = {
+        {1. / 2, 2. / 2, 3. / 2}, {4. / 2, 5. / 2, 6. / 2}, {7. / 2, 8. / 2, 9. / 2}};
+    divideSingleThread(2, b, b, 0, b.size());
+    Matrix<> result2 = {
+        {2. / 1, 2. / 2, 2. / 3}, {2. / 4, 2. / 5, 2. / 6}, {2. / 7, 2. / 8, 2. / 9}};
+    ASSERT_TRUE(equalSingleThread(a, result1, 0, a.size()));
+    ASSERT_TRUE(equalSingleThread(b, result2, 0, b.size()));
+}
 
-TEST_F(TestSameAddress, addMatrix) {}
+TEST_F(TestSameAddress, addMatrix) {
+    addSingleThread(a, a, a, 0, a.size());
+    Matrix<> result = {{1 + 1, 2 + 2, 3 + 3}, {4 + 4, 5 + 5, 6 + 6}, {7 + 7, 8 + 8, 9 + 9}};
+    ASSERT_TRUE(equalSingleThread(a, result, 0, a.size()));
+}
 
-TEST_F(TestSameAddress, sustractMatrix) {}
+TEST_F(TestSameAddress, subtractMatrix) {
+    subtractSingleThread(a, a, a, 0, a.size());
+    Matrix<> result = {{1 - 1, 2 - 2, 3 - 3}, {4 - 4, 5 - 5, 6 - 6}, {7 - 7, 8 - 8, 9 - 9}};
+    ASSERT_TRUE(equalSingleThread(a, result, 0, a.size()));
+}
 }  // namespace test
 }  // namespace mca

--- a/test/src/same_address_test.cpp
+++ b/test/src/same_address_test.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+
+#include "matrix.h"
+#include "single_thread_matrix_calculation.h"
+
+namespace mca {
+namespace test {
+class TestSameAddress : public testing::Test {
+protected:
+    Matrix<> a;
+    void SetUp() override { a = Matrix<>({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}); }
+
+    void TearDown() override {}
+};
+
+TEST_F(TestSameAddress, powNumber) {
+    powNumberSingleThread(a, 2, a, 0, a.size());
+    Matrix<> result = {{1, 2 * 2, 3 * 3}, {4 * 4, 5 * 5, 6 * 6}, {7 * 7, 8 * 8, 9 * 9}};
+    ASSERT_TRUE(equalSingleThread(a, result, 0, a.size()));
+}
+
+TEST_F(TestSameAddress, numberPow) {}
+
+TEST_F(TestSameAddress, addNumber) {}
+
+TEST_F(TestSameAddress, subtractNumber) {}
+
+TEST_F(TestSameAddress, multiplyNumber) {}
+
+TEST_F(TestSameAddress, divideNumber) {}
+
+TEST_F(TestSameAddress, addMatrix) {}
+
+TEST_F(TestSameAddress, sustractMatrix) {}
+}  // namespace test
+}  // namespace mca

--- a/test/src/single_thread_matrix_calculation_test.cpp
+++ b/test/src/single_thread_matrix_calculation_test.cpp
@@ -8,7 +8,7 @@
 
 namespace mca {
 namespace test {
-class TestSinglThreadCalculation : public testing::Test {
+class TestSingleThreadCalculation : public testing::Test {
 protected:
     Matrix<> one, negOne, output, a, b, c, d, sym, antisym;
     Matrix<int> e;
@@ -28,115 +28,115 @@ protected:
     void TearDown() override {}
 };
 
-TEST_F(TestSinglThreadCalculation, powNumberWholeMatrix) {
+TEST_F(TestSingleThreadCalculation, powNumberWholeMatrix) {
     output = Matrix<>({3, 3}, 0);
     powNumberSingleThread(a, 2, output, 0, a.size());
     Matrix<> result = Matrix<>({{0, 0, 0}, {1, 1, 1}, {4, 4, 4}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, powNumberSubMatrix) {
+TEST_F(TestSingleThreadCalculation, powNumberSubMatrix) {
     output = Matrix<>({3, 3}, -1);
     powNumberSingleThread(c, 2, output, 1, 5);
     Matrix<> result = Matrix<>({{-1, 4, 9}, {16, 25, 36}, {-1, -1, -1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, numberPowWholeMatrix) {
+TEST_F(TestSingleThreadCalculation, numberPowWholeMatrix) {
     output = Matrix<>({3, 3}, 0);
     numberPowSingleThread(2, a, output, 0, a.size());
     Matrix<> result = Matrix<>({{1, 1, 1}, {2, 2, 2}, {4, 4, 4}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, numberPowSubMatrix) {
+TEST_F(TestSingleThreadCalculation, numberPowSubMatrix) {
     output = Matrix<>({3, 3}, -1);
     numberPowSingleThread(2, c, output, 1, 5);
     Matrix<> result({{-1, 4, 8}, {16, 32, 64}, {-1, -1, -1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, lessWholeMatrix) {
+TEST_F(TestSingleThreadCalculation, lessWholeMatrix) {
     ASSERT_TRUE(lessSingleThread(a, c, 0, a.size()));
     ASSERT_FALSE(lessSingleThread(a, b, 0, a.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, lessSubMatrix) {
+TEST_F(TestSingleThreadCalculation, lessSubMatrix) {
     ASSERT_TRUE(lessSingleThread(a, c, 1, 3));
     ASSERT_FALSE(lessSingleThread(a, b, 3, 3));
 }
 
-TEST_F(TestSinglThreadCalculation, equalWholeMatrix) {
+TEST_F(TestSingleThreadCalculation, equalWholeMatrix) {
     ASSERT_TRUE(equalSingleThread(a, d, 0, a.size()));
     ASSERT_FALSE(equalSingleThread(a, b, 0, a.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, equalSubMatrix) {
+TEST_F(TestSingleThreadCalculation, equalSubMatrix) {
     ASSERT_TRUE(equalSingleThread(a, d, 1, 2));
     ASSERT_FALSE(equalSingleThread(a, b, 1, 3));
 }
 
-TEST_F(TestSinglThreadCalculation, lessEqualWholeMatrix) {
+TEST_F(TestSingleThreadCalculation, lessEqualWholeMatrix) {
     ASSERT_TRUE(lessEqualSingleThread(a, c, 0, a.size()));
     ASSERT_TRUE(lessEqualSingleThread(a, d, 0, a.size()));
     ASSERT_FALSE(lessEqualSingleThread(c, b, 0, c.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, lessEqualSubMatrix) {
+TEST_F(TestSingleThreadCalculation, lessEqualSubMatrix) {
     ASSERT_TRUE(lessEqualSingleThread(a, c, 4, 4));
     ASSERT_TRUE(lessEqualSingleThread(a, d, 4, 4));
     ASSERT_FALSE(lessEqualSingleThread(c, a, 4, 4));
 }
 
-TEST_F(TestSinglThreadCalculation, greaterWholeMatrix) {
+TEST_F(TestSingleThreadCalculation, greaterWholeMatrix) {
     ASSERT_TRUE(greaterSingleThread(c, a, 0, c.size()));
     ASSERT_FALSE(greaterSingleThread(d, a, 0, d.size()));
     ASSERT_FALSE(greaterSingleThread(d, b, 0, d.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, greaterSubMatrix) {
+TEST_F(TestSingleThreadCalculation, greaterSubMatrix) {
     ASSERT_TRUE(greaterSingleThread(c, a, 2, 3));
     ASSERT_FALSE(greaterSingleThread(a, b, 2, 3));
     ASSERT_FALSE(greaterSingleThread(a, d, 2, 3));
 }
 
-TEST_F(TestSinglThreadCalculation, greaterEqualWholeMatrix) {
+TEST_F(TestSingleThreadCalculation, greaterEqualWholeMatrix) {
     ASSERT_TRUE(greaterEqualSingleThread(a, d, 0, a.size()));
     ASSERT_TRUE(greaterEqualSingleThread(c, a, 0, c.size()));
     ASSERT_FALSE(greaterEqualSingleThread(b, c, 0, b.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, greaterEqualSubMatrix) {
+TEST_F(TestSingleThreadCalculation, greaterEqualSubMatrix) {
     ASSERT_TRUE(greaterEqualSingleThread(a, d, 3, 6));
     ASSERT_TRUE(greaterEqualSingleThread(c, b, 3, 6));
     ASSERT_FALSE(greaterEqualSingleThread(b, c, 3, 6));
 }
 
-TEST_F(TestSinglThreadCalculation, notEqualWholeMatrix) {
+TEST_F(TestSingleThreadCalculation, notEqualWholeMatrix) {
     ASSERT_TRUE(notEqualSingleThread(a, c, 0, a.size()));
     ASSERT_FALSE(notEqualSingleThread(a, d, 0, a.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, notEqualSubMatrix) {
+TEST_F(TestSingleThreadCalculation, notEqualSubMatrix) {
     ASSERT_TRUE(notEqualSingleThread(a, c, 3, 6));
     ASSERT_FALSE(notEqualSingleThread(a, d, 3, 6));
 }
 
-TEST_F(TestSinglThreadCalculation, addNumberWholeMatrix) {
+TEST_F(TestSingleThreadCalculation, addNumberWholeMatrix) {
     output = Matrix<>({3, 3}, -1);
     addSingleThread(2, a, output, 0, a.size());
     Matrix<> result({{2, 2, 2}, {3, 3, 3}, {4, 4, 4}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, addNumberSubMatrix) {
+TEST_F(TestSingleThreadCalculation, addNumberSubMatrix) {
     output = Matrix<>({3, 3}, -1);
     addSingleThread(2, a, output, 4, 4);
     Matrix<> result({{-1, -1, -1}, {-1, 3, 3}, {4, 4, -1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, subtractNumberWholeMatrix) {
+TEST_F(TestSingleThreadCalculation, subtractNumberWholeMatrix) {
     output = Matrix<>({3, 3}, -1);
     subtractSingleThread(a, 1, output, 0, a.size());
     Matrix<> result({{-1, -1, -1}, {0, 0, 0}, {1, 1, 1}});
@@ -148,7 +148,7 @@ TEST_F(TestSinglThreadCalculation, subtractNumberWholeMatrix) {
     ASSERT_TRUE(equalSingleThread(output2, result2, 0, output2.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, subtractNumberSubMatrix) {
+TEST_F(TestSingleThreadCalculation, subtractNumberSubMatrix) {
     output = Matrix<>({3, 3}, -1);
     subtractSingleThread(a, 1, output, 4, 4);
     Matrix<> result({{-1, -1, -1}, {-1, 0, 0}, {1, 1, -1}});
@@ -160,21 +160,21 @@ TEST_F(TestSinglThreadCalculation, subtractNumberSubMatrix) {
     ASSERT_TRUE(equalSingleThread(output2, result2, 0, output2.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, multiplyNumberWholeMatrix) {
+TEST_F(TestSingleThreadCalculation, multiplyNumberWholeMatrix) {
     output = Matrix<>({3, 3}, -1);
     multiplySingleThread(3, c, output, 0, c.size());
     Matrix<> result({{3, 6, 9}, {12, 15, 18}, {21, 24, 27}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, multiplyNumberSubMatrix) {
+TEST_F(TestSingleThreadCalculation, multiplyNumberSubMatrix) {
     output = Matrix<>({3, 3}, -1);
     multiplySingleThread(3, c, output, 3, 6);
     Matrix<> result({{-1, -1, -1}, {12, 15, 18}, {21, 24, 27}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, divideNumberWholeMatrix) {
+TEST_F(TestSingleThreadCalculation, divideNumberWholeMatrix) {
     output = Matrix<>({3, 3}, -1);
     divideSingleThread(c, 3, output, 0, c.size());
     Matrix<> result({{1. / 3, 2. / 3, 1}, {4. / 3, 5. / 3, 2}, {7. / 3, 8. / 3, 3}});
@@ -186,7 +186,7 @@ TEST_F(TestSinglThreadCalculation, divideNumberWholeMatrix) {
     ASSERT_TRUE(equalSingleThread(output, result2, 0, output.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, divideNumberSubMatrix) {
+TEST_F(TestSingleThreadCalculation, divideNumberSubMatrix) {
     output = Matrix<>({3, 3}, -1);
     divideSingleThread(c, 3, output, 3, 6);
     Matrix<> result({{-1, -1, -1}, {4. / 3, 5. / 3, 2}, {7. / 3, 8. / 3, 3}});
@@ -198,7 +198,7 @@ TEST_F(TestSinglThreadCalculation, divideNumberSubMatrix) {
     ASSERT_TRUE(equalSingleThread(output, result2, 0, output.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, addWholeMatrix) {
+TEST_F(TestSingleThreadCalculation, addWholeMatrix) {
     output = Matrix<>({3, 3}, 0);
     addSingleThread(a, b, output, 0, a.size());
     Matrix<> result({{1, 0, 0}, {1, 2, 1}, {2, 2, 3}});
@@ -208,7 +208,7 @@ TEST_F(TestSinglThreadCalculation, addWholeMatrix) {
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, addSubMatrix) {
+TEST_F(TestSingleThreadCalculation, addSubMatrix) {
     output = Matrix<>({3, 3}, -1);
     addSingleThread(a, b, output, 3, 6);
     Matrix<> result({{-1, -1, -1}, {1, 2, 1}, {2, 2, 3}});
@@ -218,7 +218,7 @@ TEST_F(TestSinglThreadCalculation, addSubMatrix) {
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, sustractWholeMatrix) {
+TEST_F(TestSingleThreadCalculation, sustractWholeMatrix) {
     output = Matrix<>({3, 3}, 0);
     subtractSingleThread(a, b, output, 0, a.size());
     Matrix<> result({{-1, 0, 0}, {1, 0, 1}, {2, 2, 1}});
@@ -229,7 +229,7 @@ TEST_F(TestSinglThreadCalculation, sustractWholeMatrix) {
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, sustractSubMatrix) {
+TEST_F(TestSingleThreadCalculation, sustractSubMatrix) {
     output = Matrix<>({3, 3}, -1);
     subtractSingleThread(a, b, output, 3, 6);
     Matrix<> result({{-1, -1, -1}, {1, 0, 1}, {2, 2, 1}});
@@ -240,7 +240,7 @@ TEST_F(TestSinglThreadCalculation, sustractSubMatrix) {
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, multiplyWholeMatrix) {
+TEST_F(TestSingleThreadCalculation, multiplyWholeMatrix) {
     output = Matrix<>({3, 3}, 0);
     multiplySingleThread(a, one, output, 0, a.size());
     Matrix<> result({{0, 0, 0}, {3, 3, 3}, {6, 6, 6}});
@@ -251,7 +251,7 @@ TEST_F(TestSinglThreadCalculation, multiplyWholeMatrix) {
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, multiplySubMatrix) {
+TEST_F(TestSingleThreadCalculation, multiplySubMatrix) {
     output = Matrix<>({3, 3}, -1);
     multiplySingleThread(a, one, output, 4, 5);
     Matrix<> result({{-1, -1, -1}, {-1, 3, 3}, {6, 6, 6}});
@@ -262,36 +262,36 @@ TEST_F(TestSinglThreadCalculation, multiplySubMatrix) {
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, transposeWholeMatrix) {
+TEST_F(TestSingleThreadCalculation, transposeWholeMatrix) {
     output = Matrix<>({3, 3}, 0);
     transposeSingleThread(c, output, 0, c.size());
     Matrix<> result({{1, 4, 7}, {2, 5, 8}, {3, 6, 9}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, transposeSubMatrix) {
+TEST_F(TestSingleThreadCalculation, transposeSubMatrix) {
     output = Matrix<>({3, 3}, -1);
     transposeSingleThread(c, output, 4, 5);
     Matrix<> result({{-1, -1, -1}, {-1, 5, 8}, {3, 6, 9}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
-TEST_F(TestSinglThreadCalculation, symmetricWholeMatrix) {
+TEST_F(TestSingleThreadCalculation, symmetricWholeMatrix) {
     ASSERT_TRUE(symmetricSingleThread(sym, 0, (sym.size() - sym.rows()) / 2));
     ASSERT_FALSE(symmetricSingleThread(antisym, 0, (antisym.size() - antisym.rows()) / 2));
 }
 
-TEST_F(TestSinglThreadCalculation, symmetricSubMatrix) {
+TEST_F(TestSingleThreadCalculation, symmetricSubMatrix) {
     ASSERT_TRUE(symmetricSingleThread(sym, 2, 1));
     ASSERT_FALSE(symmetricSingleThread(antisym, 2, 1));
 }
 
-TEST_F(TestSinglThreadCalculation, antisymmetricWholeMatrix) {
+TEST_F(TestSingleThreadCalculation, antisymmetricWholeMatrix) {
     ASSERT_TRUE(antisymmetricSingleThread(antisym, 0, (antisym.size() - antisym.rows()) / 2));
     ASSERT_FALSE(antisymmetricSingleThread(sym, 0, (sym.size() - sym.rows()) / 2));
 }
 
-TEST_F(TestSinglThreadCalculation, antisymmetricSubMatrix) {
+TEST_F(TestSingleThreadCalculation, antisymmetricSubMatrix) {
     ASSERT_TRUE(antisymmetricSingleThread(antisym, 0, 2));
     ASSERT_FALSE(antisymmetricSingleThread(sym, 0, 2));
 }


### PR DESCRIPTION
Finish some tests  which check whether matrix operations we write can work when `a` and `output`'s addresses are
same.

See #63.