### PR TITLE
Add type traits for Number

### DIFF
--- a/src/include/mca.h
+++ b/src/include/mca.h
@@ -1,9 +1,13 @@
 #ifndef MCA_PRIVATE_H
 #define MCA_PRIVATE_H
 
+#include <future>
 #include <thread>
+#include <type_traits>
+#include <vector>
 
 #include "matrix_declaration.h"
+#include "mca_utility.h"
 #include "single_thread_matrix_calculation.h"
 #include "thread_pool.h"
 
@@ -126,7 +130,7 @@ Matrix<std::common_type_t<T1, T2>> operator*(const Matrix<T1> &a, const Matrix<T
  *                       [3+1, 4+1]]
  * NOTE: the calculation will first calculate as std::common_type<T1, T2>
  *       then use static_cast<T1> */
-template <class T, class Number>
+template <class T, class Number, class = std::enable_if_t<!is_matrix_v<Number>>>
 Matrix<std::common_type_t<T, Number>> operator+(const Matrix<T> &a, const Number &number);
 
 /* Calculate number + a using multi-thread
@@ -139,7 +143,7 @@ Matrix<std::common_type_t<T, Number>> operator+(const Matrix<T> &a, const Number
  *                       [1+3, 1+4]]
  * NOTE: the calculation will first calculate as std::common_type<T1, T2>
  *       then use static_cast<T1> */
-template <class Number, class T>
+template <class Number, class T, class = std::enable_if_t<!is_matrix_v<Number>>>
 inline Matrix<std::common_type_t<T, Number>> operator+(const Number &number, const Matrix<T> &a);
 
 /* Calculate a - number using multi-thread
@@ -152,7 +156,7 @@ inline Matrix<std::common_type_t<T, Number>> operator+(const Number &number, con
  *                       [3-1, 4-1]]
  * NOTE: the calculation will first calculate as std::common_type<T1, T2>
  *       then use static_cast<T1> */
-template <class T, class Number>
+template <class T, class Number, class = std::enable_if_t<!is_matrix_v<Number>>>
 Matrix<std::common_type_t<T, Number>> operator-(const Matrix<T> &a, const Number &number);
 
 /* Calculate number - a using multi-thread
@@ -165,7 +169,7 @@ Matrix<std::common_type_t<T, Number>> operator-(const Matrix<T> &a, const Number
  *                       [1-3, 1-4]]
  * NOTE: the calculation will first calculate as std::common_type<T1, T2>
  *       then use static_cast<T1> */
-template <class Number, class T>
+template <class Number, class T, class = std::enable_if_t<!is_matrix_v<Number>>>
 Matrix<std::common_type_t<T, Number>> operator-(const Number &number, const Matrix<T> &a);
 
 /* Calculate a * number using multi-thread
@@ -177,7 +181,7 @@ Matrix<std::common_type_t<T, Number>> operator-(const Number &number, const Matr
  *                       [3*1, 4*1]]
  * NOTE: the calculation will first calculate as std::common_type<T1, T2>
  *       then use static_cast<T1> */
-template <class T, class Number>
+template <class T, class Number, class = std::enable_if_t<!is_matrix_v<Number>>>
 Matrix<std::common_type_t<T, Number>> operator*(const Matrix<T> &a, const Number &number);
 
 /* Calculate number * a using multi-thread
@@ -189,7 +193,7 @@ Matrix<std::common_type_t<T, Number>> operator*(const Matrix<T> &a, const Number
  *                       [1*3, 1*4]]
  * NOTE: the calculation will first calculate as std::common_type<T1, T2>
  *       then use static_cast<T1> */
-template <class Number, class T>
+template <class Number, class T, class = std::enable_if_t<!is_matrix_v<Number>>>
 Matrix<std::common_type_t<T, Number>> operator*(const Number &number, const Matrix<T> &a);
 
 /* Calculate a / number using multi-thread
@@ -201,7 +205,7 @@ Matrix<std::common_type_t<T, Number>> operator*(const Number &number, const Matr
  *                       [3/1, 4/1]]
  * NOTE: the calculation will first calculate as std::common_type<T1, T2>
  *       then use static_cast<T1> */
-template <class T, class Number>
+template <class T, class Number, class = std::enable_if_t<!is_matrix_v<Number>>>
 Matrix<std::common_type_t<T, Number>> operator/(const Matrix<T> &a, const Number &number);
 
 /* Calculate number / a using multi-thread
@@ -214,7 +218,7 @@ Matrix<std::common_type_t<T, Number>> operator/(const Matrix<T> &a, const Number
  *                       [1/3, 1/4]]
  * NOTE: the calculation will first calculate as std::common_type<T1, T2>
  *       then use static_cast<T1> */
-template <class Number, class T>
+template <class Number, class T, class = std::enable_if_t<!is_matrix_v<Number>>>
 Matrix<std::common_type_t<T, Number>> operator/(const Number &number, const Matrix<T> &a);
 
 /* Calculate a += b using multi-thread, the result will be stored in a
@@ -248,49 +252,49 @@ void operator/=(Matrix<T1> &a, const Matrix<T2> &b);
 /* Calculate a += number using multi-thread, the result will be stored in a
  * NOTE: the calculation will first calculate as std::common_type<T1, T2>
  *       then use static_cast<T1> */
-template <class T, class Number>
+template <class T, class Number, class = std::enable_if_t<!is_matrix_v<Number>>>
 void operator+=(Matrix<T> &a, const Number &number);
 
 /* Calculate number += a using multi-thread, the result will be stored in a
  * NOTE: the calculation will first calculate as std::common_type<T1, T2>
  *       then use static_cast<T1> */
-template <class Number, class T>
+template <class Number, class T, class = std::enable_if_t<!is_matrix_v<Number>>>
 inline void operator+=(const Number &number, Matrix<T> &a);
 
 /* Calculate a -= number using multi-thread, the result will be stored in a
  * NOTE: the calculation will first calculate as std::common_type<T1, T2>
  *       then use static_cast<T1> */
-template <class T, class Number>
+template <class T, class Number, class = std::enable_if_t<!is_matrix_v<Number>>>
 void operator-=(Matrix<T> &a, const Number &number);
 
 /* Calculate number -= a using multi-thread, the result will be stored in a
  * NOTE: the calculation will first calculate as std::common_type<T1, T2>
  *       then use static_cast<T1> */
-template <class Number, class T>
+template <class Number, class T, class = std::enable_if_t<!is_matrix_v<Number>>>
 void operator-=(const Number &number, Matrix<T> &a);
 
 /* Calculate a *= number using multi-thread, the result will be stored in a
  * NOTE: the calculation will first calculate as std::common_type<T1, T2>
  *       then use static_cast<T1> */
-template <class T, class Number>
+template <class T, class Number, class = std::enable_if_t<!is_matrix_v<Number>>>
 void operator*=(Matrix<T> &a, const Number &number);
 
 /* Calculate number *= a using multi-thread, the result will be stored in a
  * NOTE: the calculation will first calculate as std::common_type<T1, T2>
  *       then use static_cast<T1> */
-template <class Number, class T>
+template <class Number, class T, class = std::enable_if_t<!is_matrix_v<Number>>>
 void operator*=(const Number &number, Matrix<T> &a);
 
 /* Calculate a /= number using multi-thread, the result will be stored in a
  * NOTE: the calculation will first calculate as std::common_type<T1, T2>
  *       then use static_cast<T1> */
-template <class T, class Number>
+template <class T, class Number, class = std::enable_if_t<!is_matrix_v<Number>>>
 void operator/=(Matrix<T> &a, const Number &number);
 
 /* Calculate number /= a using multi-thread, the result will be stored in a
  * NOTE: the calculation will first calculate as std::common_type<T1, T2>
  *       then use static_cast<T1> */
-template <class Number, class T>
+template <class Number, class T, class = std::enable_if_t<!is_matrix_v<Number>>>
 void operator/=(const Number &number, Matrix<T> &a);
 
 // TODO
@@ -322,7 +326,7 @@ Matrix<std::common_type_t<T1, T2>> operator-(const Matrix<T1> &a, const Matrix<T
 template <class T1, class T2>
 Matrix<std::common_type_t<T1, T2>> operator*(const Matrix<T1> &a, const Matrix<T2> &b) {}
 
-template <class T, class Number>
+template <class T, class Number, class>
 Matrix<std::common_type_t<T, Number>> operator+(const Matrix<T> &a, const Number &number) {
     using CommonType = std::common_type_t<T, Number>;
     Matrix<CommonType> result(a.shape(), CommonType(0));
@@ -348,27 +352,27 @@ Matrix<std::common_type_t<T, Number>> operator+(const Matrix<T> &a, const Number
     return result;
 }
 
-template <class Number, class T>
+template <class Number, class T, class>
 inline Matrix<std::common_type_t<T, Number>> operator+(const Number &number, const Matrix<T> &a) {
     return a + number;
 }
 
 // TODO
-template <class T, class Number>
+template <class T, class Number, class>
 Matrix<std::common_type_t<T, Number>> operator-(const Matrix<T> &a, const Number &number) {}
 // TODO
-template <class Number, class T>
+template <class Number, class T, class>
 Matrix<std::common_type_t<T, Number>> operator-(const Number &number, const Matrix<T> &a) {}
 // TODO
-template <class T, class Number>
+template <class T, class Number, class>
 Matrix<std::common_type_t<T, Number>> operator*(const Matrix<T> &a, const Number &number) {}
-template <class Number, class T>
+template <class Number, class T, class>
 Matrix<std::common_type_t<T, Number>> operator*(const Number &number, const Matrix<T> &a) {}
 // TODO
-template <class T, class Number>
+template <class T, class Number, class>
 Matrix<std::common_type_t<T, Number>> operator/(const Matrix<T> &a, const Number &number) {}
 // TODO
-template <class Number, class T>
+template <class Number, class T, class>
 Matrix<std::common_type_t<T, Number>> operator/(const Number &number, const Matrix<T> &a) {}
 
 // TODO
@@ -384,7 +388,7 @@ void operator*=(Matrix<T1> &a, const Matrix<T2> &b) {}
 template <class T1, class T2>
 void operator/=(Matrix<T1> &a, const Matrix<T2> &b) {}
 
-template <class T, class Number>
+template <class T, class Number, class>
 void operator+=(Matrix<T> &a, const Number &number) {
     // single mode
     if (threadNum() == 0 || limit() > a.size()) {
@@ -407,27 +411,27 @@ void operator+=(Matrix<T> &a, const Number &number) {
     for (auto &item : returnValue) { item.get(); }
 }
 
-template <class Number, class T>
+template <class Number, class T, class>
 inline void operator+=(const Number &number, Matrix<T> &a) {
     a += number;
 }
 // TODO
-template <class T, class Number>
+template <class T, class Number, class>
 void operator-=(Matrix<T> &a, const Number &number) {}
 // TODO
-template <class Number, class T>
+template <class Number, class T, class>
 void operator-=(const Number &number, Matrix<T> &a) {}
 // TODO
-template <class T, class Number>
+template <class T, class Number, class>
 void operator*=(Matrix<T> &a, const Number &number) {}
 // TODO
-template <class Number, class T>
+template <class Number, class T, class>
 void operator*=(const Number &number, Matrix<T> &a) {}
 // TODO
-template <class T, class Number>
+template <class T, class Number, class>
 void operator/=(Matrix<T> &a, const Number &number) {}
 // TODO
-template <class Number, class T>
+template <class Number, class T, class>
 void operator/=(const Number &number, Matrix<T> &a) {}
 
 inline std::pair<size_t, size_t> threadCalculationTaskNum(const size_t &total) {

--- a/src/include/mca_utility.h
+++ b/src/include/mca_utility.h
@@ -1,0 +1,18 @@
+#ifndef MCA_UTILITY_H
+#define MCA_UTILITY_H
+
+#include <type_traits>
+
+#include "matrix_declaration.h"
+
+namespace mca {
+template <class T>
+struct is_matrix : std::false_type {};
+template <class T>
+struct is_matrix<Matrix<T>> : std::true_type {};
+
+// Check if a type is mca::Matrix
+template <class T>
+inline constexpr bool is_matrix_v = is_matrix<T>::value;
+}  // namespace mca
+#endif

--- a/src/include/single_thread_matrix_calculation.h
+++ b/src/include/single_thread_matrix_calculation.h
@@ -6,6 +6,7 @@
 #include <type_traits>
 
 #include "matrix_declaration.h"
+#include "mca_utility.h"
 
 namespace mca {
 /* Calculate number ^ a, and store the result in output
@@ -21,7 +22,7 @@ namespace mca {
  *              len = 4
  *              output = [[origin, 2^2, 2^3],
  *                        [2^2,    2^3, origin]] */
-template <class Number, class T, class O>
+template <class Number, class T, class O, class = std::enable_if_t<!is_matrix_v<Number>>>
 void numberPowSingleThread(const Number &number,
                            const Matrix<T> &a,
                            Matrix<O> &output,
@@ -41,7 +42,7 @@ void numberPowSingleThread(const Number &number,
  *              len = 4
  *              output = [[origin, 2^2, 3^2],
  *                        [2^2,    3^2, origin]] */
-template <class T, class Number, class O>
+template <class T, class Number, class O, class = std::enable_if_t<!is_matrix_v<Number>>>
 void powNumberSingleThread(const Matrix<T> &a,
                            const Number &number,
                            Matrix<O> &output,
@@ -184,7 +185,7 @@ void multiplySingleThread(const Matrix<T1> &a,
  *              pos = 0, len = 4
  *              output = [[2+1, 2+2,    2+3],
  *                        [2+2, origin, origin]] */
-template <class Number, class T, class O>
+template <class Number, class T, class O, class = std::enable_if_t<!is_matrix_v<Number>>>
 void addSingleThread(const Number &number,
                      const Matrix<T> &a,
                      Matrix<O> &output,
@@ -203,7 +204,7 @@ void addSingleThread(const Number &number,
  *              pos = 0, len = 4
  *              output = [[2-1, 2-2,    2-3],
  *                        [2-2, origin, origin]] */
-template <class Number, class T, class O>
+template <class Number, class T, class O, class = std::enable_if_t<!is_matrix_v<Number>>>
 void subtractSingleThread(const Number &number,
                           const Matrix<T> &a,
                           Matrix<O> &output,
@@ -222,7 +223,7 @@ void subtractSingleThread(const Number &number,
  *              pos = 0, len = 4
  *              output = [[1-2, 2-2,    3-2],
  *                        [2-2, origin, origin]] */
-template <class T, class Number, class O>
+template <class T, class Number, class O, class = std::enable_if_t<!is_matrix_v<Number>>>
 void subtractSingleThread(const Matrix<T> &a,
                           const Number &number,
                           Matrix<O> &output,
@@ -241,7 +242,7 @@ void subtractSingleThread(const Matrix<T> &a,
  *              pos = 0, len = 4
  *              output = [[2*1, 2*2,    2*3],
  *                        [2*2, origin, origin]] */
-template <class Number, class T, class O>
+template <class Number, class T, class O, class = std::enable_if_t<!is_matrix_v<Number>>>
 void multiplySingleThread(const Number &number,
                           const Matrix<T> &a,
                           Matrix<O> &output,
@@ -260,7 +261,7 @@ void multiplySingleThread(const Number &number,
  *              pos = 0, len = 4
  *              output = [[1/2, 2/2, 3/2],
  *                        [2/2, origin, origin]] */
-template <class T, class Number, class O>
+template <class T, class Number, class O, class = std::enable_if_t<!is_matrix_v<Number>>>
 void divideSingleThread(const Matrix<T> &a,
                         const Number &number,
                         Matrix<O> &output,
@@ -280,7 +281,7 @@ void divideSingleThread(const Matrix<T> &a,
  *              len = 4
  *              output = [[origin, origin, 2/3],
  *                        [2/2,    2/3,    2/4]] */
-template <class Number, class T, class O>
+template <class Number, class T, class O, class = std::enable_if_t<!is_matrix_v<Number>>>
 void divideSingleThread(const Number &number,
                         const Matrix<T> &a,
                         Matrix<O> &output,
@@ -343,7 +344,7 @@ bool antisymmetricSingleThread(const Matrix<T> &a,
                                const double &eps = 1e-100);
 
 // Those below are the implementations
-template <class Number, class T, class O>
+template <class Number, class T, class O, class>
 void numberPowSingleThread(const Number &number,
                            const Matrix<T> &a,
                            Matrix<O> &output,
@@ -358,7 +359,7 @@ void numberPowSingleThread(const Number &number,
     }
 }
 
-template <class T, class Number, class O>
+template <class T, class Number, class O, class>
 void powNumberSingleThread(const Matrix<T> &a,
                            const Number &number,
                            Matrix<O> &output,
@@ -506,7 +507,7 @@ bool notEqualSingleThread(const Matrix<T1> &a,
     return true;
 }
 
-template <class Number, class T, class O>
+template <class Number, class T, class O, class>
 void multiplySingleThread(const Number &number,
                           const Matrix<T> &a,
                           Matrix<O> &output,
@@ -575,7 +576,7 @@ void multiplySingleThread(const Matrix<T1> &a,
     }
 }
 
-template <class Number, class T, class O>
+template <class Number, class T, class O, class>
 void addSingleThread(const Number &number,
                      const Matrix<T> &a,
                      Matrix<O> &output,
@@ -588,7 +589,7 @@ void addSingleThread(const Number &number,
         output[i] = static_cast<O>(static_cast<CommonType>(number) + static_cast<CommonType>(a[i]));
 }
 
-template <class Number, class T, class O>
+template <class Number, class T, class O, class>
 void subtractSingleThread(const Number &number,
                           const Matrix<T> &a,
                           Matrix<O> &output,
@@ -601,7 +602,7 @@ void subtractSingleThread(const Number &number,
         output[i] = static_cast<O>(static_cast<CommonType>(number) - static_cast<CommonType>(a[i]));
 }
 
-template <class T, class Number, class O>
+template <class T, class Number, class O, class>
 void subtractSingleThread(const Matrix<T> &a,
                           const Number &number,
                           Matrix<O> &output,
@@ -614,7 +615,7 @@ void subtractSingleThread(const Matrix<T> &a,
         output[i] = static_cast<O>(static_cast<CommonType>(a[i]) - static_cast<CommonType>(number));
 }
 
-template <class T, class Number, class O>
+template <class T, class Number, class O, class>
 void divideSingleThread(const Matrix<T> &a,
                         const Number &number,
                         Matrix<O> &output,
@@ -627,7 +628,7 @@ void divideSingleThread(const Matrix<T> &a,
         output[i] = static_cast<O>(static_cast<CommonType>(a[i]) / static_cast<CommonType>(number));
 }
 
-template <class Number, class T, class O>
+template <class Number, class T, class O, class>
 void divideSingleThread(const Number &number,
                         const Matrix<T> &a,
                         Matrix<O> &output,

--- a/test/src/mca_test.cpp
+++ b/test/src/mca_test.cpp
@@ -27,13 +27,5 @@ TEST(TestConfiguration, setEpsilon) {
     setEpsilon(1e-7);
     ASSERT_EQ(epsilon(), 1e-7);
 }
-
-class TestMultiThreadCalculation : public testing::Test {
-protected:
-    void SetUp() override {}
-
-    void TearDown() override {}
-};
-// class Test
 }  // namespace test
 }  // namespace mca


### PR DESCRIPTION
We find that when you call `a + b` and `a` and `b` are both matrices, it will match three template functions: `operator+(Matrix, Matrix)`, `operator+(Matrix, Number)` and `operator+(Number, Matrix)`. So we define a type trait to check if a template is `mca::Matrix` and we use `std::enable_if` to enable the functions whose parameters have `Number` if and only if the `Number` is not `mca::Matrix` class.