### PR TITLE
Finish multi thread calculation methods

### DIFF
--- a/test/src/multi_thread_matrix_calculation_test.cpp
+++ b/test/src/multi_thread_matrix_calculation_test.cpp
@@ -5,6 +5,7 @@
 #include "matrix.h"
 #include "mca.h"
 #include "single_thread_matrix_calculation.h"
+
 using namespace std::chrono;
 
 namespace mca {
@@ -12,8 +13,11 @@ namespace test {
 class TestMultiThreadCalculation : public testing::Test {
 protected:
     Shape shape{9000, 9000};
-    Matrix<> output, a;
-    void SetUp() override { a = Matrix<>(shape, 123); }
+    Matrix<> output, a, b;
+    void SetUp() override {
+        a = Matrix<>(shape, 123);
+        b = Matrix<>(shape, 10.911);
+    }
     void TearDown() override {}
 };
 
@@ -129,5 +133,112 @@ TEST_F(TestMultiThreadCalculation, numSelfAddMatrix) {
     ASSERT_TRUE(equalSingleThread(output, a, 0, a.size()));
 }
 
+TEST_F(TestMultiThreadCalculation, matrixSubtractMatrix) {
+    output         = Matrix<>{shape, -1};
+    auto startTime = high_resolution_clock::now();
+    subtractSingleThread(a, b, output, 0, a.size());
+    auto endTime       = high_resolution_clock::now();
+    auto executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record time in gtest
+    testing::Test::RecordProperty("SingleTime", executionTime);
+
+    init();
+
+    // the expected time in multi thread
+    testing::Test::RecordProperty("BaseTime", executionTime / (threadNum() + 1));
+
+    // get the multi-thread mode time
+    startTime              = high_resolution_clock::now();
+    auto multiThreadOutput = a - b;
+    endTime                = high_resolution_clock::now();
+    executionTime          = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record multi-thread time in gtest
+    testing::Test::RecordProperty("MultiTime", executionTime);
+
+    // TODO this should be updated with Matrix::operator== with multi-thread
+    // make sure they are equal
+    ASSERT_TRUE(equalSingleThread(output, multiThreadOutput, 0, output.size()));
+}
+
+TEST_F(TestMultiThreadCalculation, matrixSelfSubtractMatrix) {
+    output         = Matrix<>{shape, -1};
+    auto startTime = high_resolution_clock::now();
+    subtractSingleThread(a, b, output, 0, a.size());
+    auto endTime       = high_resolution_clock::now();
+    auto executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record time in gtest
+    testing::Test::RecordProperty("SingleTime", executionTime);
+
+    init();
+
+    // the expected time in multi thread
+    testing::Test::RecordProperty("BaseTime", executionTime / (threadNum() + 1));
+
+    // get the multi-thread mode time
+    startTime = high_resolution_clock::now();
+    a -= b;
+    endTime       = high_resolution_clock::now();
+    executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record multi-thread time in gtest
+    testing::Test::RecordProperty("MultiTime", executionTime);
+
+    // TODO this should be updated with Matrix::operator== with multi-thread
+    // make sure they are equal
+    ASSERT_TRUE(equalSingleThread(output, a, 0, a.size()));
+}
+
+TEST_F(TestMultiThreadCalculation, matrixAddMatrix) {
+    output         = Matrix<>{shape, -1};
+    auto startTime = high_resolution_clock::now();
+    addSingleThread(a, b, output, 0, a.size());
+    auto endTime       = high_resolution_clock::now();
+    auto executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record time in gtest
+    testing::Test::RecordProperty("SingleTime", executionTime);
+
+    init();
+
+    // the expected time in multi thread
+    testing::Test::RecordProperty("BaseTime", executionTime / (threadNum() + 1));
+
+    // get the multi-thread mode time
+    startTime              = high_resolution_clock::now();
+    auto multiThreadOutput = a + b;
+    endTime                = high_resolution_clock::now();
+    executionTime          = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record multi-thread time in gtest
+    testing::Test::RecordProperty("MultiTime", executionTime);
+
+    // TODO this should be updated with Matrix::operator== with multi-thread
+    // make sure they are equal
+    ASSERT_TRUE(equalSingleThread(output, multiThreadOutput, 0, output.size()));
+}
+
+TEST_F(TestMultiThreadCalculation, matrixSelfAddMatrix) {
+    output         = Matrix<>{shape, -1};
+    auto startTime = high_resolution_clock::now();
+    addSingleThread(a, b, output, 0, a.size());
+    auto endTime       = high_resolution_clock::now();
+    auto executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record time in gtest
+    testing::Test::RecordProperty("SingleTime", executionTime);
+
+    init();
+
+    // the expected time in multi thread
+    testing::Test::RecordProperty("BaseTime", executionTime / (threadNum() + 1));
+
+    // get the multi-thread mode time
+    startTime = high_resolution_clock::now();
+    a += b;
+    endTime       = high_resolution_clock::now();
+    executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record multi-thread time in gtest
+    testing::Test::RecordProperty("MultiTime", executionTime);
+
+    // TODO this should be updated with Matrix::operator== with multi-thread
+    // make sure they are equal
+    ASSERT_TRUE(equalSingleThread(output, a, 0, a.size()));
+}
 }  // namespace test
 }  // namespace mca

--- a/test/src/multi_thread_matrix_test.cpp
+++ b/test/src/multi_thread_matrix_test.cpp
@@ -197,5 +197,63 @@ TEST_F(TestMatrixMultiThread, powNumberToOutput) {
     // make sure they are equal
     ASSERT_TRUE(equalSingleThread(output, multiOutput, 0, output.size()));
 }
+
+TEST_F(TestMatrixMultiThread, numberPow) {
+    Matrix<int> output      = {shape, -1};
+    Matrix<int> multiOutput = {shape, -1};
+    // first use numberPowSingleThread to get the single mode time
+    auto startTime = high_resolution_clock::now();
+    numberPowSingleThread(2, singleThread, output, 0, singleThread.size());
+    auto endTime       = high_resolution_clock::now();
+    auto executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record time in gtest
+    testing::Test::RecordProperty("SingleTime", executionTime);
+
+    init();
+    // the expected time in multi thread
+    testing::Test::RecordProperty("BaseTime", executionTime / (threadNum() + 1));
+
+    // get the multi-thread mode time
+    startTime = high_resolution_clock::now();
+    // get multi-thread pownumber in multiThread
+    multiThread.numberPow(2);
+    endTime       = high_resolution_clock::now();
+    executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record multi-thread time in gtest
+    testing::Test::RecordProperty("MultiTime", executionTime);
+
+    // TODO this should be updated with Matrix::operator== with multi-thread
+    // make sure they are equal
+    ASSERT_TRUE(equalSingleThread(output, multiThread, 0, output.size()));
+}
+
+TEST_F(TestMatrixMultiThread, numberPowToOutput) {
+    Matrix<int> output      = {shape, -1};
+    Matrix<int> multiOutput = {shape, -1};
+    // first use numberPowSingleThread to get the single mode time
+    auto startTime = high_resolution_clock::now();
+    numberPowSingleThread(2, singleThread, output, 0, singleThread.size());
+    auto endTime       = high_resolution_clock::now();
+    auto executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record time in gtest
+    testing::Test::RecordProperty("SingleTime", executionTime);
+
+    init();
+    // the expected time in multi thread
+    testing::Test::RecordProperty("BaseTime", executionTime / (threadNum() + 1));
+
+    // get the multi-thread mode time
+    startTime = high_resolution_clock::now();
+    // get multi-thread pownumber in multi_output
+    multiThread.numberPow(2, multiOutput);
+    endTime       = high_resolution_clock::now();
+    executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record multi-thread time in gtest
+    testing::Test::RecordProperty("MultiTime", executionTime);
+
+    // TODO this should be updated with Matrix::operator== with multi-thread
+    // make sure they are equal
+    ASSERT_TRUE(equalSingleThread(output, multiOutput, 0, output.size()));
+}
 }  // namespace test
 }  // namespace mca


### PR DESCRIPTION
There are what have been done by this commit:
* operator-(const Matrix<T1> &a, const Matrix<T2> &b)
* operator-=(Matrix<T1> &a, const Matrix<T2> &b)
* Matrix<ELEMENT_TYPE>::numberPow(Number &&number, const Matrix<O> &output)
* Matrix<ELEMENT_TYPE>::numberPow(const Number &number)
* operator+(const Matrix<T1> &a, const Matrix<T2> &b)
* operator+=(Matrix<T1> &a, const Matrix<T2> &b)

See #48.