### PR TITLE
Enhance unit tests

### DIFF
--- a/src/include/matrix.h
+++ b/src/include/matrix.h
@@ -449,7 +449,7 @@ template <class ELEMENT_TYPE>
 template <class T>
 Matrix<ELEMENT_TYPE> &Matrix<ELEMENT_TYPE>::operator=(const Matrix<T> &other) {
     if (capacity < other.size()) {
-        capacity = _shape.size();
+        capacity = other.size();
         data     = std::make_unique<ELEMENT_TYPE[]>(other.size());
     }
     _shape = other.shape();
@@ -467,7 +467,7 @@ Matrix<ELEMENT_TYPE> &Matrix<ELEMENT_TYPE>::operator=(const Matrix<T> &other) {
                 }
             });
     }
-    for (size_t i = (res.second - 1) * res.first; i < res.second * res.first; i++) {
+    for (size_t i = (res.second - 1) * res.first; i < size(); i++) {
         (*this)[i] = static_cast<ELEMENT_TYPE>(other[i]);
     }
     for (auto &item : returnValue) { item.get(); }
@@ -515,7 +515,7 @@ Matrix<ELEMENT_TYPE> &Matrix<ELEMENT_TYPE>::operator=(
             });
     }
 
-    for (size_t i = (res.second - 1) * res.first; i < res.second * res.first; i++) {
+    for (size_t i = (res.second - 1) * res.first; i < size(); i++) {
         (*this)[i] =
             static_cast<ELEMENT_TYPE>(std::data(std::data(init)[i / columns()])[i % columns()]);
     }
@@ -556,7 +556,7 @@ Matrix<ELEMENT_TYPE> &Matrix<ELEMENT_TYPE>::operator=(const std::vector<std::vec
                 }
             });
     }
-    for (size_t i = (res.second - 1) * res.first; i < res.second * res.first; i++) {
+    for (size_t i = (res.second - 1) * res.first; i < size(); i++) {
         (*this)[i] = static_cast<ELEMENT_TYPE>(init[i / columns()][i % columns()]);
     }
     for (auto &item : returnValue) { item.get(); }
@@ -580,7 +580,7 @@ Matrix<ELEMENT_TYPE> &Matrix<ELEMENT_TYPE>::operator=(const T *data) {
                 }
             });
     }
-    for (size_t i = (res.second - 1) * res.first; i < res.second * res.first; i++) {
+    for (size_t i = (res.second - 1) * res.first; i < size(); i++) {
         (*this)[i] = static_cast<ELEMENT_TYPE>(data[i]);
     }
     for (auto &item : returnValue) { item.get(); }
@@ -665,7 +665,7 @@ void Matrix<ELEMENT_TYPE>::fill(const ELEMENT_TYPE &value, const size_t &pos) {
             });
     }
     // let main thread calculate too
-    std::fill(dataPtr() + (res.second - 1) * res.first, dataPtr() + size(), value);
+    std::fill(dataPtr() + (res.second - 1) * res.first + pos, dataPtr() + size(), value);
 
     // make sure all the sub threads are finished
     for (auto &item : returnValue) { item.get(); }

--- a/src/include/mca.h
+++ b/src/include/mca.h
@@ -406,7 +406,7 @@ Matrix<std::common_type_t<T, Number>> operator+(const Matrix<T> &a, const Number
     // let main thread calculate too
     addSingleThread(
         number, a, result, (res.second - 1) * res.first, a.size() - (res.second - 1) * res.first);
-    // make sure all the sub thread are finished
+    // make sure all the sub threads are finished
     for (auto &item : returnValue) { item.get(); }
     return result;
 }
@@ -437,7 +437,10 @@ Matrix<std::common_type_t<T, Number>> operator/(const Number &number, const Matr
 template <class T1, class T2>
 void operator+=(Matrix<T1> &a, const Matrix<T2> &b) {
     assert(a.shape() == b.shape());
-    if (threadNum() == 0 || limit() > a.size()) { addSingleThread(a, b, a, 0, a.size()); }
+    if (threadNum() == 0 || limit() > a.size()) {
+        addSingleThread(a, b, a, 0, a.size());
+        return;
+    }
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<void>> returnValue(res.second - 1);
     for (size_t i = 0; i < res.second - 1; i++) {
@@ -452,7 +455,10 @@ void operator+=(Matrix<T1> &a, const Matrix<T2> &b) {
 template <class T1, class T2>
 void operator-=(Matrix<T1> &a, const Matrix<T2> &b) {
     assert(a.shape() == b.shape());
-    if (threadNum() == 0 || limit() > a.size()) { addSingleThread(a, b, a, 0, a.size()); }
+    if (threadNum() == 0 || limit() > a.size()) {
+        subtractSingleThread(a, b, a, 0, a.size());
+        return;
+    }
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<void>> returnValue(res.second - 1);
     for (size_t i = 0; i < res.second - 1; i++) {
@@ -511,7 +517,7 @@ void operator+=(Matrix<T> &a, const Number &number) {
     // let main thread calculate too
     addSingleThread(
         number, a, a, (res.second - 1) * res.first, a.size() - (res.second - 1) * res.first);
-    // make sure all the sub thread are finished
+    // make sure all the sub threads are finished
     for (auto &item : returnValue) { item.get(); }
 }
 

--- a/src/include/thread_pool.h
+++ b/src/include/thread_pool.h
@@ -13,35 +13,35 @@
 #include <utility>
 
 namespace mca {
-// the class is not thread-safe
-// synchronizations are needed when more than one thread operate the same object of the class
+/* the class is not thread-safe
+ * synchronizations are needed when more than one thread operate the same object of the class */
 class ThreadPool {
 public:
-    // size is the size of the thread pool
+    /* size is the size of the thread pool */
     inline ThreadPool(size_t size = 0);
 
-    // set a new size, this will not clear the task queue
-    // this will wait for all the running threads finish their current tasks, then stop them
-    // and create new threads
+    /* set a new size, and this will clear the task queue
+     * this will wait for all the running threads finish their current tasks, then stop them
+     * and create new threads */
     void resize(size_t newSize);
 
-    // the size of the thread pool
+    /* the size of the thread pool */
     inline size_t size();
 
-    // add a task to the thread pool
-    // this will return a std::future
-    // you can use the object's get() to get the return value of your task
-    // NOTE: you can not add a task to a thread pool whose size is 0
+    /* add a task to the thread pool
+     * this will return a std::future
+     * you can use the object's get() to get the return value of your task
+     * NOTE: you can not add a task to a thread pool whose size is 0 */
     template <class Function, class... Args>
     auto addTask(Function &&func, Args &&...args)
         -> std::future<std::invoke_result_t<Function, Args...>>;
 
-    // stop all threads
-    // if a thread is running
-    // this will wait for the thread to finish
+    /* stop all threads and clear the task queue
+     * if a thread is running
+     * this will wait for the thread to finish */
     void clear();
 
-    // the destructor will stop all the threads
+    /* the destructor will stop all the threads */
     inline ~ThreadPool();
 
 private:

--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -4,6 +4,8 @@ namespace mca {
 void ThreadPool::resize(size_t newSize) {
     clear();
     stopped.store(false, std::memory_order_relaxed);
+    assert(taskQueue.size() == 0);
+    taskQueue.reserve(newSize);
     while (taskQueue.size() < newSize) {
         taskQueue.emplace_back(std::queue<std::function<void()>>());
     }
@@ -30,5 +32,6 @@ void ThreadPool::clear() {
         threadQueue.front().join();
         threadQueue.pop();
     }
+    std::vector<std::queue<std::function<void()>>>().swap(taskQueue);
 }
 }  // namespace mca

--- a/test/src/mca_test.cpp
+++ b/test/src/mca_test.cpp
@@ -7,10 +7,12 @@
 namespace mca {
 namespace test {
 TEST(TestConfiguration, init) {
-    init();
-    ASSERT_EQ(threadNum(), std::thread::hardware_concurrency() - 1);
+    constexpr size_t THREAD_NUM = 10;
+    init(THREAD_NUM);
+    ASSERT_EQ(threadNum(), THREAD_NUM);
     ASSERT_EQ(limit(), 623);
     ASSERT_EQ(epsilon(), 1e-100);
+    init(0);
 }
 
 TEST(TestConfiguration, setThreadNum) {

--- a/test/src/thread_pool_test.cpp
+++ b/test/src/thread_pool_test.cpp
@@ -26,7 +26,6 @@ TEST(TestThreadPool, addTask) {
         resultVector.emplace_back(
             tp.addTask([](size_t a, size_t b) -> size_t { return a + b; }, (size_t)2, (size_t)3));
     }
-    tp.resize(5);
     for (size_t i = 0; i < taskNum; i++) {
         ASSERT_EQ(resultVector[i].get(), (size_t)2 + (size_t)3);
     }


### PR DESCRIPTION
We found that the single-thread mode parts of multi-thread calculations are not covered by unit tests. So we rewrite some unit tests to cover those parts. Besides, we update some tests to make them more random.

See #74.

Besides, we chose to use smaller matrices to test.

We make `clear` of the thread poll more reasonable, now `clear` will clear task queue, too.

We find that there are some multi-thread calculation in main thread will exceed the address boundary, we use `size()` to make sure this will not happen.

Besides, we find that when generating coverage reports, the unit tests will run in multi-thread except for the first one. This is because we don't use `init(0)` to make sure the single-mode running in single-mode, and use command `./mca_unit_test` to run will not run every unit test in a new process compared with `ctest`. So we add `init(0)` in the `TearDown` part to make sure the size of the thread pool is zero before running unit tests.

We find that if use the default value (the number of `cpu`s), this process will never finish on `git action`, so we use `THREAD_NUM` to limit the number of threads, the variable is set be `10` which means there will be `11` (`10` sub threads and `1` main thread) threads join calculation.