### PR TITLE
Update coverage reports build type

### DIFF
--- a/.github/workflows/codecov-action.yml
+++ b/.github/workflows/codecov-action.yml
@@ -14,7 +14,7 @@ jobs:
       - name: build
         shell: bash
         run: |
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -Dmca_GENERATE_COVERAGE=on
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -Dmca_GENERATE_COVERAGE=on
           cmake --build build
 
       - name: Install LCOV

--- a/.github/workflows/codecov-on-develop.yml
+++ b/.github/workflows/codecov-on-develop.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           git fetch origin develop:develop
           git checkout develop
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -Dmca_GENERATE_COVERAGE=on
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -Dmca_GENERATE_COVERAGE=on
           cmake --build build
 
       - name: Install LCOV

--- a/.github/workflows/codecov-on-master.yml
+++ b/.github/workflows/codecov-on-master.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           git fetch origin master:master
           git checkout master
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -Dmca_GENERATE_COVERAGE=on
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -Dmca_GENERATE_COVERAGE=on
           cmake --build build
 
       - name: Install LCOV

--- a/test/src/multi_thread_matrix_test.cpp
+++ b/test/src/multi_thread_matrix_test.cpp
@@ -24,7 +24,7 @@ protected:
     Matrix<> a, b;
     Matrix<> singleOutput, multiOutput;
     size_t exponent;
-    Shape powShape{200, 200};
+    Shape powShape{100, 100};
 
     void SetUp() override {
         generator.seed(time(nullptr));


### PR DESCRIPTION
Now `coverage report`s will build on `Debug` version rather than `Release` version.

See #79.