### PR TITLE
Add explicit for some constructors

### DIFF
--- a/src/include/matrix.h
+++ b/src/include/matrix.h
@@ -18,9 +18,9 @@ struct Shape {
     size_t rows    = 0;
     size_t columns = 0;
 
-    Shape() = default;
+    explicit Shape() = default;
 
-    Shape(size_t rows, size_t columns);
+    explicit Shape(size_t rows, size_t columns);
 
     bool operator==(const Shape &other) const;
 
@@ -35,32 +35,32 @@ public:
     using ElementType = ELEMENT_TYPE;
 
     /* Construct an empty matrix */
-    Matrix() = default;
+    explicit Matrix() = default;
 
     /* Construct an identity matrix */
-    Matrix(const Shape &shape);
+    explicit Matrix(const Shape &shape);
 
     /* Construct a matrix from a initializer_list
      * You can use this like Matrix<>({{1, 2}, {3, 4}})
      * NOTE: if you use Matrix({{1, 2}, {3, 4}}) the ELEMENT_TYPE will be int rather than double */
-    inline Matrix(const std::initializer_list<std::initializer_list<ELEMENT_TYPE>> &init);
+    explicit inline Matrix(const std::initializer_list<std::initializer_list<ELEMENT_TYPE>> &init);
 
     /* Construct a matrix from a vector */
-    inline Matrix(const std::vector<std::vector<ELEMENT_TYPE>> &init);
+    explicit inline Matrix(const std::vector<std::vector<ELEMENT_TYPE>> &init);
 
     /* Construct a matrix from a pointer
      * when len is less than shape.size(), the rest part will be filled with ELEMENT_TYPE() */
-    inline Matrix(const Shape &shape, const ELEMENT_TYPE *data, const size_t &len);
+    explicit inline Matrix(const Shape &shape, const ELEMENT_TYPE *data, const size_t &len);
 
     /* Construct a matrix with shape and defaultValue */
-    inline Matrix(const Shape &shape, const ELEMENT_TYPE &defaultValue);
+    explicit inline Matrix(const Shape &shape, const ELEMENT_TYPE &defaultValue);
 
     /* Construct a diagonal matrix, the diag is the diagonal elements
      * Matrix<>({1, 2, 3, 4}) will construct a matrix whose shape is 4 * 4,
      * and diagonal elements are 1, 2, 3, 4 other elements will be ELEMENT_TYPE()
      * In this case, double() will be 0 */
-    Matrix(const std::initializer_list<ELEMENT_TYPE> &diag);
-    Matrix(const std::vector<ELEMENT_TYPE> &diag);
+    explicit Matrix(const std::initializer_list<ELEMENT_TYPE> &diag);
+    explicit Matrix(const std::vector<ELEMENT_TYPE> &diag);
 
     /* Copy constructor
      * If the other matrix's ELEMENT_TYPE is not same with current matrix,
@@ -359,7 +359,7 @@ inline Matrix<ELEMENT_TYPE>::Matrix(const Shape &shape,
     if (shape.size() == 0) { return; }
     capacity   = shape.size();
     this->data = std::make_unique<ELEMENT_TYPE[]>(shape.size());
-    _shape     = {std::min(len, shape.size()), 1};
+    _shape     = Shape{std::min(len, shape.size()), 1};
     *this      = data;
     _shape     = shape;
     if (size() <= len) { return; }
@@ -379,7 +379,7 @@ inline Matrix<ELEMENT_TYPE>::Matrix(const Shape &shape, const ELEMENT_TYPE &defa
 template <class ELEMENT_TYPE>
 Matrix<ELEMENT_TYPE>::Matrix(const std::initializer_list<ELEMENT_TYPE> &diag) {
     if (diag.size() == 0) { return; }
-    _shape = {diag.size(), diag.size()};
+    _shape = Shape{diag.size(), diag.size()};
     data   = std::make_unique<ELEMENT_TYPE[]>(size());
     fill(ELEMENT_TYPE());
     if (threadNum() == 0 || limit() > rows()) {
@@ -403,7 +403,7 @@ Matrix<ELEMENT_TYPE>::Matrix(const std::initializer_list<ELEMENT_TYPE> &diag) {
 template <class ELEMENT_TYPE>
 Matrix<ELEMENT_TYPE>::Matrix(const std::vector<ELEMENT_TYPE> &diag) {
     if (diag.size() == 0) { return; }
-    _shape = {diag.size(), diag.size()};
+    _shape = Shape{diag.size(), diag.size()};
     data   = std::make_unique<ELEMENT_TYPE[]>(size());
     fill(ELEMENT_TYPE());
     if (threadNum() == 0 || limit() > rows()) {

--- a/test/src/different_type_test.cpp
+++ b/test/src/different_type_test.cpp
@@ -11,10 +11,10 @@ protected:
     Matrix<int> intMatrix, intOutput, intResult;
 
     void SetUp() override {
-        doubleMatrix = Matrix<>({3, 3}, -1.);
-        doubleOutput = Matrix<>({3, 3}, 0.);
-        intMatrix    = Matrix<int>({3, 3}, -1);
-        intOutput    = Matrix<int>({3, 3}, 0);
+        doubleMatrix = Matrix<>(Shape{3, 3}, -1.);
+        doubleOutput = Matrix<>(Shape{3, 3}, 0.);
+        intMatrix    = Matrix<int>(Shape{3, 3}, -1);
+        intOutput    = Matrix<int>(Shape{3, 3}, 0);
     }
 
     void TearDown() override {}
@@ -31,126 +31,126 @@ TEST_F(TestDifferentType, differentTypeComparison) {
 
 TEST_F(TestDifferentType, differentTypeCalculation) {
     addSingleThread(intMatrix, doubleMatrix, doubleOutput, 0, intMatrix.size());
-    doubleResult = Matrix<>({3, 3}, -2.);
+    doubleResult = Matrix<>(Shape{3, 3}, -2.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     addSingleThread(intMatrix, doubleMatrix, intOutput, 0, intMatrix.size());
-    intResult = Matrix<int>({3, 3}, -2);
+    intResult = Matrix<int>(Shape{3, 3}, -2);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
 
     subtractSingleThread(intMatrix, doubleMatrix, doubleOutput, 0, intMatrix.size());
-    doubleResult = Matrix<>({3, 3}, 0);
+    doubleResult = Matrix<>(Shape{3, 3}, 0);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     subtractSingleThread(intMatrix, doubleMatrix, intOutput, 0, intMatrix.size());
-    intResult = Matrix<int>({3, 3}, 0);
+    intResult = Matrix<int>(Shape{3, 3}, 0);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
 
     multiplySingleThread(intMatrix, doubleMatrix, doubleOutput, 0, intMatrix.size());
-    doubleResult = Matrix<>({3, 3}, 3.);
+    doubleResult = Matrix<>(Shape{3, 3}, 3.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     multiplySingleThread(intMatrix, doubleMatrix, intOutput, 0, intMatrix.size());
-    intResult = Matrix<int>({3, 3}, 3);
+    intResult = Matrix<int>(Shape{3, 3}, 3);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
 
     powNumberSingleThread(doubleMatrix, 2, doubleOutput, 0, doubleMatrix.size());
-    doubleResult = Matrix<>({3, 3}, 1.);
+    doubleResult = Matrix<>(Shape{3, 3}, 1.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     powNumberSingleThread(doubleMatrix, 2, intOutput, 0, doubleMatrix.size());
-    intResult = Matrix<int>({3, 3}, 1);
+    intResult = Matrix<int>(Shape{3, 3}, 1);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
     powNumberSingleThread(intMatrix, 2, doubleOutput, 0, intMatrix.size());
-    doubleResult = Matrix<>({3, 3}, 1.);
+    doubleResult = Matrix<>(Shape{3, 3}, 1.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     powNumberSingleThread(intMatrix, 2, intOutput, 0, intMatrix.size());
-    intResult = Matrix<int>({3, 3}, 1);
+    intResult = Matrix<int>(Shape{3, 3}, 1);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
 
     numberPowSingleThread(2, doubleMatrix, doubleOutput, 0, doubleMatrix.size());
-    doubleResult = Matrix<>({3, 3}, std::pow(2, -1));
+    doubleResult = Matrix<>(Shape{3, 3}, std::pow(2, -1));
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     numberPowSingleThread(2, doubleMatrix, intOutput, 0, doubleMatrix.size());
-    intResult = Matrix<int>({3, 3}, static_cast<int>(std::pow(2, -1)));
+    intResult = Matrix<int>(Shape{3, 3}, static_cast<int>(std::pow(2, -1)));
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
     numberPowSingleThread(2, intMatrix, doubleOutput, 0, intMatrix.size());
-    doubleResult = Matrix<>({3, 3}, std::pow(2, -1));
+    doubleResult = Matrix<>(Shape{3, 3}, std::pow(2, -1));
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     numberPowSingleThread(2, intMatrix, intOutput, 0, intMatrix.size());
-    intResult = Matrix<int>({3, 3}, static_cast<int>(std::pow(2, -1)));
+    intResult = Matrix<int>(Shape{3, 3}, static_cast<int>(std::pow(2, -1)));
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
 
     addSingleThread(1, doubleMatrix, doubleOutput, 0, doubleMatrix.size());
-    doubleResult = Matrix<>({3, 3}, 0.);
+    doubleResult = Matrix<>(Shape{3, 3}, 0.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     addSingleThread(1, doubleMatrix, intOutput, 0, doubleMatrix.size());
-    intResult = Matrix<int>({3, 3}, 0);
+    intResult = Matrix<int>(Shape{3, 3}, 0);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
     addSingleThread(1, intMatrix, doubleOutput, 0, intMatrix.size());
-    doubleResult = Matrix<>({3, 3}, 0.);
+    doubleResult = Matrix<>(Shape{3, 3}, 0.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     addSingleThread(1, intMatrix, intOutput, 0, intMatrix.size());
-    intResult = Matrix<int>({3, 3}, 0);
+    intResult = Matrix<int>(Shape{3, 3}, 0);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
 
     subtractSingleThread(1, doubleMatrix, doubleOutput, 0, doubleMatrix.size());
-    doubleResult = Matrix<>({3, 3}, 2.);
+    doubleResult = Matrix<>(Shape{3, 3}, 2.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     subtractSingleThread(1, doubleMatrix, intOutput, 0, doubleMatrix.size());
-    intResult = Matrix<int>({3, 3}, 2);
+    intResult = Matrix<int>(Shape{3, 3}, 2);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
     subtractSingleThread(1, intMatrix, doubleOutput, 0, intMatrix.size());
-    doubleResult = Matrix<>({3, 3}, 2.);
+    doubleResult = Matrix<>(Shape{3, 3}, 2.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     subtractSingleThread(1, intMatrix, intOutput, 0, intMatrix.size());
-    intResult = Matrix<int>({3, 3}, 2);
+    intResult = Matrix<int>(Shape{3, 3}, 2);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
     subtractSingleThread(doubleMatrix, 1, doubleOutput, 0, doubleMatrix.size());
-    doubleResult = Matrix<>({3, 3}, -2.);
+    doubleResult = Matrix<>(Shape{3, 3}, -2.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     subtractSingleThread(doubleMatrix, 1, intOutput, 0, doubleMatrix.size());
-    intResult = Matrix<int>({3, 3}, -2);
+    intResult = Matrix<int>(Shape{3, 3}, -2);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
     subtractSingleThread(intMatrix, 1, doubleOutput, 0, intMatrix.size());
-    doubleResult = Matrix<>({3, 3}, -2.);
+    doubleResult = Matrix<>(Shape{3, 3}, -2.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     subtractSingleThread(intMatrix, 1, intOutput, 0, intMatrix.size());
-    intResult = Matrix<int>({3, 3}, -2);
+    intResult = Matrix<int>(Shape{3, 3}, -2);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
 
     multiplySingleThread(-1, doubleMatrix, doubleOutput, 0, doubleMatrix.size());
-    doubleResult = Matrix<>({3, 3}, 1.);
+    doubleResult = Matrix<>(Shape{3, 3}, 1.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     multiplySingleThread(-1, doubleMatrix, intOutput, 0, doubleMatrix.size());
-    intResult = Matrix<int>({3, 3}, 1);
+    intResult = Matrix<int>(Shape{3, 3}, 1);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
     multiplySingleThread(-1, intMatrix, doubleOutput, 0, intMatrix.size());
-    doubleResult = Matrix<>({3, 3}, 1.);
+    doubleResult = Matrix<>(Shape{3, 3}, 1.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     multiplySingleThread(-1, intMatrix, intOutput, 0, intMatrix.size());
-    intResult = Matrix<int>({3, 3}, 1);
+    intResult = Matrix<int>(Shape{3, 3}, 1);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
 
     divideSingleThread(-1, doubleMatrix, doubleOutput, 0, doubleMatrix.size());
-    doubleResult = Matrix<>({3, 3}, 1.);
+    doubleResult = Matrix<>(Shape{3, 3}, 1.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     divideSingleThread(-1, doubleMatrix, intOutput, 0, doubleMatrix.size());
-    intResult = Matrix<int>({3, 3}, 1);
+    intResult = Matrix<int>(Shape{3, 3}, 1);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
     divideSingleThread(-1, intMatrix, doubleOutput, 0, intMatrix.size());
-    doubleResult = Matrix<>({3, 3}, 1.);
+    doubleResult = Matrix<>(Shape{3, 3}, 1.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     divideSingleThread(-1, intMatrix, intOutput, 0, intMatrix.size());
-    intResult = Matrix<int>({3, 3}, 1);
+    intResult = Matrix<int>(Shape{3, 3}, 1);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
     divideSingleThread(doubleMatrix, 3, doubleOutput, 0, doubleMatrix.size());
-    doubleResult = Matrix<>({3, 3}, -1. / 3);
+    doubleResult = Matrix<>(Shape{3, 3}, -1. / 3);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     divideSingleThread(doubleMatrix, 3, intOutput, 0, doubleMatrix.size());
-    intResult = Matrix<int>({3, 3}, -1. / 3);
+    intResult = Matrix<int>(Shape{3, 3}, -1. / 3);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
     divideSingleThread(intMatrix, 3, doubleOutput, 0, intMatrix.size());
-    doubleResult = Matrix<>({3, 3}, -1. / 3);
+    doubleResult = Matrix<>(Shape{3, 3}, -1. / 3);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     divideSingleThread(intMatrix, 3, intOutput, 0, intMatrix.size());
-    intResult = Matrix<int>({3, 3}, -1. / 3);
+    intResult = Matrix<int>(Shape{3, 3}, -1. / 3);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
 }
 }  // namespace test

--- a/test/src/matrix_test.cpp
+++ b/test/src/matrix_test.cpp
@@ -61,7 +61,7 @@ TEST(TestMatrix, constructors) {
 
     // construct from a pointer
     int data[] = {1, 2, 3};
-    Matrix<int> m4({3, 3}, &data[0], 3);
+    Matrix<int> m4(Shape{3, 3}, &data[0], 3);
     result = Matrix<int>({{1, 2, 3}, {0, 0, 0}, {0, 0, 0}});
     ASSERT_TRUE(equalSingleThread(m4, result, 0, m4.size()));
 
@@ -93,7 +93,7 @@ TEST(TestMatrix, assignments) {
     ASSERT_EQ(m.dataPtr(), nullptr);
 
     // move assignment from Matrix<int>
-    m = Matrix<int>({3, 3}, 1);
+    m = Matrix<int>(Shape{3, 3}, 1);
     ASSERT_EQ(m.shape(), Shape(3, 3));
     ASSERT_NE(m.dataPtr(), nullptr);
     for (size_t i = 0; i < m.rows(); i++) {
@@ -101,12 +101,12 @@ TEST(TestMatrix, assignments) {
     }
 
     // copy assignment from Matrix<double>
-    m = Matrix<>({3, 3}, 1.5);
-    Matrix<int> result({3, 3}, 1);
+    m = Matrix<>(Shape{3, 3}, 1.5);
+    Matrix<int> result(Shape{3, 3}, 1);
     ASSERT_TRUE(equalSingleThread(m, result, 0, m.size()));
 
     // copy assignment from Matrix<int>
-    Matrix<int> newN({3, 3}, 1);
+    Matrix<int> newN(Shape{3, 3}, 1);
     m = newN;
     ASSERT_EQ(m.shape(), Shape(3, 3));
     ASSERT_NE(m.dataPtr(), nullptr);
@@ -115,14 +115,14 @@ TEST(TestMatrix, assignments) {
     }
 
     // copy assignment from Matrix<double>
-    Matrix<double> newM = Matrix<>({3, 3}, 1.5);
+    Matrix<double> newM = Matrix<>(Shape{3, 3}, 1.5);
     result              = newM;
     ASSERT_TRUE(equalSingleThread(m, result, 0, m.size()));
 
     // copy assignment from a pointer
     double data[9] = {1.5, 2.5, 3.5};
     m              = &data[0];
-    result         = Matrix<>({3, 3}, &data[0], 3);
+    result         = Matrix<>(Shape{3, 3}, &data[0], 3);
     ASSERT_TRUE(equalSingleThread(m, result, 0, m.size()));
 
     // copy assignment from std::initializer_list
@@ -152,14 +152,14 @@ TEST(TestMatrix, geter) {
 TEST(TestMatrix, reshape) {
     Matrix<int> m({{1, 2, 3, 4, 5, 6}});
     ASSERT_EQ(m.shape(), Shape(1, 6));
-    m.reshape({2, 3});
+    m.reshape(Shape{2, 3});
     ASSERT_EQ(m.shape(), Shape(2, 3));
 }
 
 TEST(TestMatrix, isSquare) {
     Matrix<int> m(Shape{3, 3});
     ASSERT_TRUE(m.isSquare());
-    m.reshape({1, 9});
+    m.reshape(Shape{1, 9});
     ASSERT_FALSE(m.isSquare());
 }
 }  // namespace test

--- a/test/src/same_address_test.cpp
+++ b/test/src/same_address_test.cpp
@@ -10,69 +10,72 @@ namespace test {
 class TestSameAddress : public testing::Test {
 protected:
     Matrix<> a, b;
-    void SetUp() override {
-        a = Matrix<>({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}});
-        b = a;
-    }
+    void SetUp() override { a = b = Matrix<>({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}); }
 
     void TearDown() override {}
 };
 
 TEST_F(TestSameAddress, powNumber) {
     powNumberSingleThread(a, 2, a, 0, a.size());
-    Matrix<> result = {{1, 2 * 2, 3 * 3}, {4 * 4, 5 * 5, 6 * 6}, {7 * 7, 8 * 8, 9 * 9}};
+    Matrix<> result{{1, 2 * 2, 3 * 3}, {4 * 4, 5 * 5, 6 * 6}, {7 * 7, 8 * 8, 9 * 9}};
     ASSERT_TRUE(equalSingleThread(a, result, 0, a.size()));
 }
 
 TEST_F(TestSameAddress, numberPow) {
     numberPowSingleThread(2, a, a, 0, a.size());
-    Matrix<> result = {{std::pow(2, 1), std::pow(2, 2), std::pow(2, 3)},
-                       {std::pow(2, 4), std::pow(2, 5), std::pow(2, 6)},
-                       {std::pow(2, 7), std::pow(2, 8), std::pow(2, 9)}};
+    Matrix<> result({{std::pow(2, 1), std::pow(2, 2), std::pow(2, 3)},
+                     {std::pow(2, 4), std::pow(2, 5), std::pow(2, 6)},
+                     {std::pow(2, 7), std::pow(2, 8), std::pow(2, 9)}});
     ASSERT_TRUE(equalSingleThread(a, result, 0, a.size()));
 }
 
 TEST_F(TestSameAddress, addNumber) {
     addSingleThread(2, a, a, 0, a.size());
-    Matrix<> result = {{2 + 1, 2 + 2, 2 + 3}, {2 + 4, 2 + 5, 2 + 6}, {2 + 7, 2 + 8, 2 + 9}};
+    Matrix<> result({{2 + 1, 2 + 2, 2 + 3}, {2 + 4, 2 + 5, 2 + 6}, {2 + 7, 2 + 8, 2 + 9}});
     ASSERT_TRUE(equalSingleThread(a, result, 0, a.size()));
 }
 
 TEST_F(TestSameAddress, subtractNumber) {
     subtractSingleThread(a, 2, a, 0, a.size());
-    Matrix<> result1 = {{1 - 2, 2 - 2, 3 - 2}, {4 - 2, 5 - 2, 6 - 2}, {7 - 2, 8 - 2, 9 - 2}};
+    Matrix<> result1({{1 - 2, 2 - 2, 3 - 2}, {4 - 2, 5 - 2, 6 - 2}, {7 - 2, 8 - 2, 9 - 2}});
     subtractSingleThread(2, b, b, 0, b.size());
-    Matrix<> result2 = {{2 - 1, 2 - 2, 2 - 3}, {2 - 4, 2 - 5, 2 - 6}, {2 - 7, 2 - 8, 2 - 9}};
+    Matrix<> result2({{2 - 1, 2 - 2, 2 - 3}, {2 - 4, 2 - 5, 2 - 6}, {2 - 7, 2 - 8, 2 - 9}});
     ASSERT_TRUE(equalSingleThread(a, result1, 0, a.size()));
     ASSERT_TRUE(equalSingleThread(b, result2, 0, b.size()));
 }
 
 TEST_F(TestSameAddress, multiplyNumber) {
     multiplySingleThread(2, a, a, 0, a.size());
-    Matrix<> result = {{2 * 1, 2 * 2, 2 * 3}, {2 * 4, 2 * 5, 2 * 6}, {2 * 7, 2 * 8, 2 * 9}};
+    Matrix<> result({{2 * 1, 2 * 2, 2 * 3}, {2 * 4, 2 * 5, 2 * 6}, {2 * 7, 2 * 8, 2 * 9}});
     ASSERT_TRUE(equalSingleThread(a, result, 0, a.size()));
 }
 
 TEST_F(TestSameAddress, divideNumber) {
     divideSingleThread(a, 2, a, 0, a.size());
-    Matrix<> result1 = {
-        {1. / 2, 2. / 2, 3. / 2}, {4. / 2, 5. / 2, 6. / 2}, {7. / 2, 8. / 2, 9. / 2}};
+    // clang-format off
+    Matrix<> result1({{1. / 2, 2. / 2, 3. / 2},
+                      {4. / 2, 5. / 2, 6. / 2},
+                      {7. / 2, 8. / 2, 9. / 2}});
+    // clang-format on
     divideSingleThread(2, b, b, 0, b.size());
-    Matrix<> result2 = {
-        {2. / 1, 2. / 2, 2. / 3}, {2. / 4, 2. / 5, 2. / 6}, {2. / 7, 2. / 8, 2. / 9}};
+    // clang-format off
+    Matrix<> result2({{2. / 1, 2. / 2, 2. / 3},
+                      {2. / 4, 2. / 5, 2. / 6},
+                      {2. / 7, 2. / 8, 2. / 9}});
+    // clang-format on
     ASSERT_TRUE(equalSingleThread(a, result1, 0, a.size()));
     ASSERT_TRUE(equalSingleThread(b, result2, 0, b.size()));
 }
 
 TEST_F(TestSameAddress, addMatrix) {
     addSingleThread(a, a, a, 0, a.size());
-    Matrix<> result = {{1 + 1, 2 + 2, 3 + 3}, {4 + 4, 5 + 5, 6 + 6}, {7 + 7, 8 + 8, 9 + 9}};
+    Matrix<> result({{1 + 1, 2 + 2, 3 + 3}, {4 + 4, 5 + 5, 6 + 6}, {7 + 7, 8 + 8, 9 + 9}});
     ASSERT_TRUE(equalSingleThread(a, result, 0, a.size()));
 }
 
 TEST_F(TestSameAddress, subtractMatrix) {
     subtractSingleThread(a, a, a, 0, a.size());
-    Matrix<> result = {{1 - 1, 2 - 2, 3 - 3}, {4 - 4, 5 - 5, 6 - 6}, {7 - 7, 8 - 8, 9 - 9}};
+    Matrix<> result({{1 - 1, 2 - 2, 3 - 3}, {4 - 4, 5 - 5, 6 - 6}, {7 - 7, 8 - 8, 9 - 9}});
     ASSERT_TRUE(equalSingleThread(a, result, 0, a.size()));
 }
 }  // namespace test

--- a/test/src/single_thread_matrix_calculation_test.cpp
+++ b/test/src/single_thread_matrix_calculation_test.cpp
@@ -14,8 +14,8 @@ protected:
     Matrix<int> e, f;
 
     void SetUp() override {
-        one     = Matrix<>({3, 3}, 1);
-        negOne  = Matrix<>({3, 3}, -1);
+        one     = Matrix<>(Shape{3, 3}, 1);
+        negOne  = Matrix<>(Shape{3, 3}, -1);
         a       = Matrix<>({{0, 0, 0}, {1, 1, 1}, {2, 2, 2}});
         b       = Matrix<>({{1, 0, 0}, {0, 1, 0}, {0, 0, 1}});
         c       = Matrix<>({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}});
@@ -30,28 +30,28 @@ protected:
 };
 
 TEST_F(TestSingleThreadCalculation, powNumberWholeMatrix) {
-    output = Matrix<>({3, 3}, 0);
+    output = Matrix<>(Shape{3, 3}, 0);
     powNumberSingleThread(a, 2, output, 0, a.size());
     Matrix<> result = Matrix<>({{0, 0, 0}, {1, 1, 1}, {4, 4, 4}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, powNumberSubMatrix) {
-    output = Matrix<>({3, 3}, -1);
+    output = Matrix<>(Shape{3, 3}, -1);
     powNumberSingleThread(c, 2, output, 1, 5);
     Matrix<> result = Matrix<>({{-1, 4, 9}, {16, 25, 36}, {-1, -1, -1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, numberPowWholeMatrix) {
-    output = Matrix<>({3, 3}, 0);
+    output = Matrix<>(Shape{3, 3}, 0);
     numberPowSingleThread(2, a, output, 0, a.size());
     Matrix<> result = Matrix<>({{1, 1, 1}, {2, 2, 2}, {4, 4, 4}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, numberPowSubMatrix) {
-    output = Matrix<>({3, 3}, -1);
+    output = Matrix<>(Shape{3, 3}, -1);
     numberPowSingleThread(2, c, output, 1, 5);
     Matrix<> result({{-1, 4, 8}, {16, 32, 64}, {-1, -1, -1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
@@ -125,83 +125,83 @@ TEST_F(TestSingleThreadCalculation, notEqualSubMatrix) {
 }
 
 TEST_F(TestSingleThreadCalculation, addNumberWholeMatrix) {
-    output = Matrix<>({3, 3}, -1);
+    output = Matrix<>(Shape{3, 3}, -1);
     addSingleThread(2, a, output, 0, a.size());
     Matrix<> result({{2, 2, 2}, {3, 3, 3}, {4, 4, 4}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, addNumberSubMatrix) {
-    output = Matrix<>({3, 3}, -1);
+    output = Matrix<>(Shape{3, 3}, -1);
     addSingleThread(2, a, output, 4, 4);
     Matrix<> result({{-1, -1, -1}, {-1, 3, 3}, {4, 4, -1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, subtractNumberWholeMatrix) {
-    output = Matrix<>({3, 3}, -1);
+    output = Matrix<>(Shape{3, 3}, -1);
     subtractSingleThread(a, 1, output, 0, a.size());
     Matrix<> result({{-1, -1, -1}, {0, 0, 0}, {1, 1, 1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 
-    Matrix<int> output2({3, 3}, -1);
+    Matrix<int> output2(Shape{3, 3}, -1);
     subtractSingleThread(9, e, output2, 0, a.size());
     Matrix<> result2({{8, 7, 6}, {7, 6, 5}, {3, 3, 3}});
     ASSERT_TRUE(equalSingleThread(output2, result2, 0, output2.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, subtractNumberSubMatrix) {
-    output = Matrix<>({3, 3}, -1);
+    output = Matrix<>(Shape{3, 3}, -1);
     subtractSingleThread(a, 1, output, 4, 4);
     Matrix<> result({{-1, -1, -1}, {-1, 0, 0}, {1, 1, -1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 
-    Matrix<int> output2({3, 3}, -1);
+    Matrix<int> output2(Shape{3, 3}, -1);
     subtractSingleThread(9, e, output2, 3, 6);
     Matrix<> result2({{-1, -1, -1}, {7, 6, 5}, {3, 3, 3}});
     ASSERT_TRUE(equalSingleThread(output2, result2, 0, output2.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, multiplyNumberWholeMatrix) {
-    output = Matrix<>({3, 3}, -1);
+    output = Matrix<>(Shape{3, 3}, -1);
     multiplySingleThread(3, c, output, 0, c.size());
     Matrix<> result({{3, 6, 9}, {12, 15, 18}, {21, 24, 27}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, multiplyNumberSubMatrix) {
-    output = Matrix<>({3, 3}, -1);
+    output = Matrix<>(Shape{3, 3}, -1);
     multiplySingleThread(3, c, output, 3, 6);
     Matrix<> result({{-1, -1, -1}, {12, 15, 18}, {21, 24, 27}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, divideNumberWholeMatrix) {
-    output = Matrix<>({3, 3}, -1);
+    output = Matrix<>(Shape{3, 3}, -1);
     divideSingleThread(c, 3, output, 0, c.size());
     Matrix<> result({{1. / 3, 2. / 3, 1}, {4. / 3, 5. / 3, 2}, {7. / 3, 8. / 3, 3}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 
-    output = Matrix<>({3, 3}, -1);
+    output = Matrix<>(Shape{3, 3}, -1);
     divideSingleThread(9, c, output, 0, c.size());
     Matrix<> result2({{9, 9. / 2, 3}, {9. / 4, 9. / 5, 9. / 6}, {9. / 7, 9. / 8, 1}});
     ASSERT_TRUE(equalSingleThread(output, result2, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, divideNumberSubMatrix) {
-    output = Matrix<>({3, 3}, -1);
+    output = Matrix<>(Shape{3, 3}, -1);
     divideSingleThread(c, 3, output, 3, 6);
     Matrix<> result({{-1, -1, -1}, {4. / 3, 5. / 3, 2}, {7. / 3, 8. / 3, 3}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 
-    output = Matrix<>({3, 3}, -1);
+    output = Matrix<>(Shape{3, 3}, -1);
     divideSingleThread(9, c, output, 3, 6);
     Matrix<> result2({{-1, -1, -1}, {9. / 4, 9. / 5, 9. / 6}, {9. / 7, 9. / 8, 1}});
     ASSERT_TRUE(equalSingleThread(output, result2, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, addWholeMatrix) {
-    output = Matrix<>({3, 3}, 0);
+    output = Matrix<>(Shape{3, 3}, 0);
     addSingleThread(a, b, output, 0, a.size());
     Matrix<> result({{1, 0, 0}, {1, 2, 1}, {2, 2, 3}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
@@ -211,7 +211,7 @@ TEST_F(TestSingleThreadCalculation, addWholeMatrix) {
 }
 
 TEST_F(TestSingleThreadCalculation, addSubMatrix) {
-    output = Matrix<>({3, 3}, -1);
+    output = Matrix<>(Shape{3, 3}, -1);
     addSingleThread(a, b, output, 3, 6);
     Matrix<> result({{-1, -1, -1}, {1, 2, 1}, {2, 2, 3}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
@@ -221,7 +221,7 @@ TEST_F(TestSingleThreadCalculation, addSubMatrix) {
 }
 
 TEST_F(TestSingleThreadCalculation, sustractWholeMatrix) {
-    output = Matrix<>({3, 3}, 0);
+    output = Matrix<>(Shape{3, 3}, 0);
     subtractSingleThread(a, b, output, 0, a.size());
     Matrix<> result({{-1, 0, 0}, {1, 0, 1}, {2, 2, 1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
@@ -232,7 +232,7 @@ TEST_F(TestSingleThreadCalculation, sustractWholeMatrix) {
 }
 
 TEST_F(TestSingleThreadCalculation, sustractSubMatrix) {
-    output = Matrix<>({3, 3}, -1);
+    output = Matrix<>(Shape{3, 3}, -1);
     subtractSingleThread(a, b, output, 3, 6);
     Matrix<> result({{-1, -1, -1}, {1, 0, 1}, {2, 2, 1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
@@ -243,18 +243,18 @@ TEST_F(TestSingleThreadCalculation, sustractSubMatrix) {
 }
 
 TEST_F(TestSingleThreadCalculation, multiplyWholeMatrix) {
-    output = Matrix<>({3, 3}, 0);
+    output = Matrix<>(Shape{3, 3}, 0);
     multiplySingleThread(a, one, output, 0, a.size());
     Matrix<> result({{0, 0, 0}, {3, 3, 3}, {6, 6, 6}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 
     multiplySingleThread(one, a, output, 0, one.size());
-    result = Matrix<>({3, 3}, 3);
+    result = Matrix<>(Shape{3, 3}, 3);
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, multiplySubMatrix) {
-    output = Matrix<>({3, 3}, -1);
+    output = Matrix<>(Shape{3, 3}, -1);
     multiplySingleThread(a, one, output, 4, 5);
     Matrix<> result({{-1, -1, -1}, {-1, 3, 3}, {6, 6, 6}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
@@ -265,14 +265,14 @@ TEST_F(TestSingleThreadCalculation, multiplySubMatrix) {
 }
 
 TEST_F(TestSingleThreadCalculation, transposeWholeMatrix) {
-    output = Matrix<>({3, 3}, 0);
+    output = Matrix<>(Shape{3, 3}, 0);
     transposeSingleThread(c, output, 0, c.size());
     Matrix<> result({{1, 4, 7}, {2, 5, 8}, {3, 6, 9}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, transposeSubMatrix) {
-    output = Matrix<>({3, 3}, -1);
+    output = Matrix<>(Shape{3, 3}, -1);
     transposeSingleThread(c, output, 4, 5);
     Matrix<> result({{-1, -1, -1}, {-1, 5, 8}, {3, 6, 9}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));


### PR DESCRIPTION
We do this to avoid convert implicitly.

See #86.