### PR TITLE
Add a class called Diag

### DIFF
--- a/src/include/diag.h
+++ b/src/include/diag.h
@@ -1,0 +1,57 @@
+#ifndef MCA_DIAG_H
+#define MCA_DIAG_H
+#include <cstddef>
+#include <initializer_list>
+#include <vector>
+
+namespace mca {
+// non-movable, non-copyable, non-assignable
+template <class Container>
+class _Diag {
+public:
+    _Diag() = delete;
+
+    _Diag(_Diag &&other) noexcept = delete;
+    _Diag(const _Diag &other)     = delete;
+
+    _Diag &operator=(const _Diag &) = delete;
+    _Diag &operator=(_Diag &&)      = delete;
+
+    inline explicit _Diag(const Container &other);
+    inline explicit _Diag(Container &&other);
+
+    inline const typename Container::value_type &operator[](const size_t &i) const;
+    inline size_t size() const;
+
+private:
+    const Container &_diagRef;
+    Container _diag;
+};
+
+template <class Container>
+_Diag<Container>::_Diag(const Container &_diag) : _diagRef(_diag) {}
+
+template <class Container>
+inline _Diag<Container>::_Diag(Container &&_diag) : _diag(std::move(_diag)), _diagRef(_diag) {}
+
+template <class Container>
+inline const typename Container::value_type &_Diag<Container>::operator[](const size_t &i) const {
+    return std::data(_diagRef)[i];
+}
+
+template <class Container>
+inline size_t _Diag<Container>::size() const {
+    return _diagRef.size();
+}
+
+template <class Container>
+inline _Diag<std::decay_t<Container>> Diag(Container &&container) {
+    return _Diag<std::decay_t<Container>>(std::forward<Container &&>(container));
+}
+
+template <class T>
+inline _Diag<std::initializer_list<T>> Diag(std::initializer_list<T> &&container) {
+    return _Diag<std::initializer_list<T>>(std::forward<std::initializer_list<T> &&>(container));
+}
+}  // namespace mca
+#endif

--- a/src/include/identity_matrix.h
+++ b/src/include/identity_matrix.h
@@ -1,8 +1,14 @@
 #ifndef MCA_IDENTITY_MATRIX_H
 #define MCA_IDENTITY_MATRIX_H
 namespace mca {
+// non-copyable, non-movable, non-assignable
 struct IdentityMatrix {
-    explicit IdentityMatrix() = default;
+    inline IdentityMatrix() = default;
+
+    IdentityMatrix(IdentityMatrix &&other)            = delete;
+    IdentityMatrix(const IdentityMatrix &other)       = delete;
+    IdentityMatrix &operator=(const IdentityMatrix &) = delete;
+    IdentityMatrix &operator=(IdentityMatrix &&)      = delete;
 };
 }  // namespace mca
 #endif

--- a/src/include/shape.h
+++ b/src/include/shape.h
@@ -6,15 +6,15 @@ struct Shape {
     size_t rows    = 0;
     size_t columns = 0;
 
-    explicit inline Shape() = default;
+    inline Shape() = default;
 
-    explicit inline Shape(size_t rows, size_t columns);
+    inline explicit Shape(size_t rows, size_t columns);
 
-    bool operator==(const Shape &other) const;
+    inline bool operator==(const Shape &other) const;
 
-    bool operator!=(const Shape &other) const;
+    inline bool operator!=(const Shape &other) const;
 
-    size_t size() const;
+    inline size_t size() const;
 };
 
 inline Shape::Shape(size_t rows, size_t columns) : rows(rows), columns(columns) {}

--- a/test/src/matrix_test.cpp
+++ b/test/src/matrix_test.cpp
@@ -4,6 +4,7 @@
 
 #include <vector>
 
+#include "diag.h"
 #include "single_thread_matrix_calculation.h"
 
 namespace mca {
@@ -72,10 +73,10 @@ TEST(TestMatrix, constructors) {
     ASSERT_TRUE(equalSingleThread(m5, result, 0, m5.size()));
 
     // construct a diagonal matrix
-    Matrix<int> m6({1, 2, 3});
+    Matrix<int> m6(Diag({1, 2, 3}));
     result = Matrix<int>({{1, 0, 0}, {0, 2, 0}, {0, 0, 3}});
     ASSERT_TRUE(equalSingleThread(m6, result, 0, m6.size()));
-    Matrix<int> m7(std::vector<int>{1, 2, 3});
+    Matrix<int> m7(Diag(std::vector<int>{1, 2, 3}));
     result = Matrix<int>({{1, 0, 0}, {0, 2, 0}, {0, 0, 3}});
     ASSERT_TRUE(equalSingleThread(m6, result, 0, m6.size()));
 
@@ -117,23 +118,6 @@ TEST(TestMatrix, assignments) {
     // copy assignment from Matrix<double>
     Matrix<double> newM = Matrix<>(Shape{3, 3}, 1.5);
     result              = newM;
-    ASSERT_TRUE(equalSingleThread(m, result, 0, m.size()));
-
-    // copy assignment from a pointer
-    double data[9] = {1.5, 2.5, 3.5};
-    m              = &data[0];
-    result         = Matrix<>(Shape{3, 3}, &data[0], 3);
-    ASSERT_TRUE(equalSingleThread(m, result, 0, m.size()));
-
-    // copy assignment from std::initializer_list
-    m      = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
-    result = Matrix<>({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}});
-    ASSERT_TRUE(equalSingleThread(m, result, 0, m.size()));
-
-    // copy assignment from a std::vector
-    std::vector<std::vector<int>> vec{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
-    m = Matrix<>();
-    m = vec;
     ASSERT_TRUE(equalSingleThread(m, result, 0, m.size()));
 }
 

--- a/test/src/multi_thread_matrix_test.cpp
+++ b/test/src/multi_thread_matrix_test.cpp
@@ -4,6 +4,7 @@
 #include <ctime>
 #include <random>
 
+// #include "diag.h"
 #include "identity_matrix.h"
 #include "matrix.h"
 #include "mca.h"
@@ -88,7 +89,7 @@ TEST_F(TestMatrixMultiThread, constructors) {
     Matrix<> m4(vec);
 
     // construct a diagonal matrix
-    Matrix<> m5(diag);
+    Matrix<> m5(Diag(diag));
 
     // copy constructor
     Matrix<> m6(a);
@@ -118,7 +119,7 @@ TEST_F(TestMatrixMultiThread, constructors) {
     Matrix<> n4(vec);
 
     // construct a diagonal matrix
-    Matrix<> n5(diag);
+    Matrix<> n5(Diag(diag));
 
     // copy constructor
     Matrix<> n6(a);
@@ -154,10 +155,6 @@ TEST_F(TestMatrixMultiThread, assignments) {
     auto startTime = high_resolution_clock::now();
     // copy from a Matrix<>
     n1 = a;
-    // copy assignment from a pointer
-    n2 = array.data();
-    // copy assignment from a std::vector
-    n3 = vec;
     // copy assignment from Matrix<int>
     n4                 = Matrix<int>(squareShape, value);
     auto endTime       = high_resolution_clock::now();
@@ -172,10 +169,6 @@ TEST_F(TestMatrixMultiThread, assignments) {
     startTime = high_resolution_clock::now();
     // copy from a Matrix<>
     m1 = a;
-    // copy assignment from a pointer
-    m2 = array.data();
-    // copy assignment from a std::vector
-    m3 = vec;
     // copy assignment from Matrix<int>
     m4            = Matrix<int>(squareShape, value);
     endTime       = high_resolution_clock::now();
@@ -388,7 +381,7 @@ TEST_F(TestMatrixMultiThread, powToOutput) {
 TEST_F(TestMatrixMultiThread, constructorFromDiag) {
     // single assignment thread mode
     auto startTime = high_resolution_clock::now();
-    Matrix<int> n1({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+    Matrix<int> n1(Diag({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
     auto endTime       = high_resolution_clock::now();
     auto executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
     // record time in gtest
@@ -399,7 +392,7 @@ TEST_F(TestMatrixMultiThread, constructorFromDiag) {
     // the expected time in multi thread
     testing::Test::RecordProperty("BaseTime", executionTime / (threadNum() + 1));
     startTime = high_resolution_clock::now();
-    Matrix<int> m1({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+    Matrix<int> m1(Diag({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
     endTime       = high_resolution_clock::now();
     executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
     // record time in gtest
@@ -411,21 +404,21 @@ TEST_F(TestMatrixMultiThread, constructorFromDiag) {
 
 TEST_F(TestMatrixMultiThread, assignmentFromInitializerList) {
     // create a null matrix
-    a = std::initializer_list<std::initializer_list<double>>{};
+    a = Matrix<>(std::initializer_list<std::initializer_list<double>>{});
     // create a column null matirx
-    b = std::initializer_list<std::initializer_list<double>>{{}, {}};
+    b = Matrix<>(std::initializer_list<std::initializer_list<double>>{{}, {}});
 
     auto startTime     = high_resolution_clock::now();
-    singleOutput       = {{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-                          {0, 1, 0, 0, 0, 0, 0, 0, 0, 0},
-                          {0, 0, 2, 0, 0, 0, 0, 0, 0, 0},
-                          {0, 0, 0, 3, 0, 0, 0, 0, 0, 0},
-                          {0, 0, 0, 0, 4, 0, 0, 0, 0, 0},
-                          {0, 0, 0, 0, 0, 5, 0, 0, 0, 0},
-                          {0, 0, 0, 0, 0, 0, 6, 0, 0, 0},
-                          {0, 0, 0, 0, 0, 0, 0, 7, 0, 0},
-                          {0, 0, 0, 0, 0, 0, 0, 0, 8, 0},
-                          {0, 0, 0, 0, 0, 0, 0, 0, 0, 9}};
+    singleOutput       = Matrix<>({{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                                   {0, 1, 0, 0, 0, 0, 0, 0, 0, 0},
+                                   {0, 0, 2, 0, 0, 0, 0, 0, 0, 0},
+                                   {0, 0, 0, 3, 0, 0, 0, 0, 0, 0},
+                                   {0, 0, 0, 0, 4, 0, 0, 0, 0, 0},
+                                   {0, 0, 0, 0, 0, 5, 0, 0, 0, 0},
+                                   {0, 0, 0, 0, 0, 0, 6, 0, 0, 0},
+                                   {0, 0, 0, 0, 0, 0, 0, 7, 0, 0},
+                                   {0, 0, 0, 0, 0, 0, 0, 0, 8, 0},
+                                   {0, 0, 0, 0, 0, 0, 0, 0, 0, 9}});
     auto endTime       = high_resolution_clock::now();
     auto executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
     // record time in gtest
@@ -436,16 +429,16 @@ TEST_F(TestMatrixMultiThread, assignmentFromInitializerList) {
     // the expected time in multi thread
     testing::Test::RecordProperty("BaseTime", executionTime / (threadNum() + 1));
     startTime     = high_resolution_clock::now();
-    multiOutput   = {{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-                     {0, 1, 0, 0, 0, 0, 0, 0, 0, 0},
-                     {0, 0, 2, 0, 0, 0, 0, 0, 0, 0},
-                     {0, 0, 0, 3, 0, 0, 0, 0, 0, 0},
-                     {0, 0, 0, 0, 4, 0, 0, 0, 0, 0},
-                     {0, 0, 0, 0, 0, 5, 0, 0, 0, 0},
-                     {0, 0, 0, 0, 0, 0, 6, 0, 0, 0},
-                     {0, 0, 0, 0, 0, 0, 0, 7, 0, 0},
-                     {0, 0, 0, 0, 0, 0, 0, 0, 8, 0},
-                     {0, 0, 0, 0, 0, 0, 0, 0, 0, 9}};
+    multiOutput   = Matrix<>({{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                              {0, 1, 0, 0, 0, 0, 0, 0, 0, 0},
+                              {0, 0, 2, 0, 0, 0, 0, 0, 0, 0},
+                              {0, 0, 0, 3, 0, 0, 0, 0, 0, 0},
+                              {0, 0, 0, 0, 4, 0, 0, 0, 0, 0},
+                              {0, 0, 0, 0, 0, 5, 0, 0, 0, 0},
+                              {0, 0, 0, 0, 0, 0, 6, 0, 0, 0},
+                              {0, 0, 0, 0, 0, 0, 0, 7, 0, 0},
+                              {0, 0, 0, 0, 0, 0, 0, 0, 8, 0},
+                              {0, 0, 0, 0, 0, 0, 0, 0, 0, 9}});
     endTime       = high_resolution_clock::now();
     executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
     // record time in gtest
@@ -461,9 +454,9 @@ TEST_F(TestMatrixMultiThread, assignmentFromInitializerList) {
 
 TEST_F(TestMatrixMultiThread, assignmentFromVector) {
     // create a null matrix
-    a = std::vector<std::vector<double>>{};
+    a = Matrix<>(std::vector<std::vector<double>>{});
     // create a column null matirx
-    b = std::vector<std::vector<double>>{{}, {}};
+    b = Matrix<>(std::vector<std::vector<double>>{{}, {}});
 
     ASSERT_EQ(a.shape(), Shape(0, 0));
     ASSERT_EQ(b.shape(), Shape(2, 0));


### PR DESCRIPTION
Now we define a new class called `Diag`, this class receives a container that can be the parameter of `std::data`, e.g `std::vector`, `std::initializer_list`. This class is for specifying a diagonal matrix. For example, now if you want to create a diagonal matrix, you must use `Matrix<> a(Diag({1, 2, 3}))` to create a diagonal matrix whose diagonal elements are `1, 2, 3`.

See https://github.com/Kaiser-Yang/matrix-calculation-accelerator/issues/90.

Besides, we find that assignments from a pointer, `std::vector` and `std::initializer_list` are not reasonable, so we remove the assignments. Now if you want to assign from a `std::vector`, you must use `a = Matrix<>(vec)`, which will make the codes more readable. The same applies to others (`a = Matrix<>(a.shape(), pointer, a.size())` and `a = Matrix<>({{1, 2, 3}, {2, 3, 4}})`).

We also update `IdentityMatrix`. We find this class should only be constructed from the construct with no parameters. And we remove some redundant `explicit`, because `explicit` is for preventing implicit conversions, there is no need to specify `explicit` for copy constructors, move constructors, and constructors with no parameters.