### PR TITLE
Update the function of resize in class ThreadPool

### DIFF
--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -2,6 +2,9 @@
 
 namespace mca {
 void ThreadPool::resize(size_t newSize) {
+    // if the new size is equal with the old one, do nothing
+    if (newSize == threadQueue.size()) { return; }
+
     clear();
     stopped.store(false, std::memory_order_relaxed);
     assert(taskQueue.size() == 0);


### PR DESCRIPTION
We let the function `resize` do nothing when the new size is equal with the old one.

See #100.