### PR TITLE
Refactor matrix to remove memory wastes and to reuse codes

### DIFF
--- a/src/include/mca/__mca_internal/single_thread_matrix_calculation.h
+++ b/src/include/mca/__mca_internal/single_thread_matrix_calculation.h
@@ -61,7 +61,7 @@ bool lessSingleThread(const Matrix<T1> &a,
                       const size_t &len,
                       const double &eps = 1e-100);
 
-/* Check if the elements of the sub-matrix of a are all equal with the sub-matrix of b's
+/* Check if the elements of the sub-matrix of a are all equal to the sub-matrix of b's
  * This will only check the a[pos:pos+len] with b[pos:pos+len]
  * NOTE: eps will be used when T1 or T2 is floating number */
 template <class T1, class T2>
@@ -71,7 +71,7 @@ bool equalSingleThread(const Matrix<T1> &a,
                        const size_t &len,
                        const double &eps = 1e-100);
 
-/* Check if the elements of the sub-matrix of a are all less than or equal with the sub-matrix of
+/* Check if the elements of the sub-matrix of a are all less than or equal to the sub-matrix of
  * This will only check the a[pos:pos+len] with b[pos:pos+len]
  * pos: one-demensional starting index of the matrix
  * len: number of elements to be checked
@@ -95,7 +95,7 @@ bool greaterSingleThread(const Matrix<T1> &a,
                          const size_t &len,
                          const double &eps = 1e-100);
 
-/* Check if the elements of the sub-matrix of a are all greater than or equal with the sub-matrix of
+/* Check if the elements of the sub-matrix of a are all greater than or equal to the sub-matrix of
  * b's This will only check the a[pos:pos+len] with
  * b[pos:pos+len]
  * NOTE: eps will be used when T1 or T2 is floating number */
@@ -106,7 +106,7 @@ bool greaterEqualSingleThread(const Matrix<T1> &a,
                               const size_t &len,
                               const double &eps = 1e-100);
 
-/* Check if any element of the sub-matrix of a is not equal with the sub-matrix of b's
+/* Check if any element of the sub-matrix of a is not equal to the sub-matrix of b's
  * This will only check the a[pos:pos+len] with
  * b[pos:pos+len]
  * NOTE: eps will be used when T1 or T2 is floating number */
@@ -164,7 +164,7 @@ void subtractSingleThread(const Matrix<T1> &a,
  * pos: start position
  * len: length of calculation
  * NOTE: a must have the same shape with output and b
- *       &a must not be equal with &output
+ *       &a must not be equal to &output
  *       the matrix which will be calculated must in range */
 template <class T1, class T2, class O>
 void multiplySingleThread(const Matrix<T1> &a,
@@ -294,7 +294,7 @@ void divideSingleThread(const Number &number,
  * len: length of elements
  * NOTE: a must have the same shape with output after transposition
  *       the matrix which will be calculated must in range
- *       &a must not be equal with &output
+ *       &a must not be equal to &output
  * for example: number = 2,
  *              a = [[1, 2, 3],
  *                   [2, 3, 4]]
@@ -313,7 +313,7 @@ void transposeSingleThread(const Matrix<T> &a,
  * pos: start position from the first element which will be used
  * len: length of elements
  * NOTE: a must be a square matrix
- *       pos + len must less than or equal with (a.size() - a.rows())/2
+ *       pos + len must less than or equal to (a.size() - a.rows())/2
  * for example: a = [[1, 2, 3],
  *                   [2, 3, 4],
  *                   [3, 6, 5]]
@@ -330,7 +330,7 @@ bool symmetricSingleThread(const Matrix<T> &a,
  * pos: start pos from the first element which will be used
  * len: length of elements
  * NOTE: a must be a square matrix
- *       pos + len must less than or equal with (a.size() - a.rows())/2
+ *       pos + len must less than or equal to (a.size() - a.rows())/2
  * for example: a = [[1,  2, 3],
  *                   [2,  3, 4],
  *                   [3, -4, 5]]

--- a/src/include/mca/matrix.h
+++ b/src/include/mca/matrix.h
@@ -106,7 +106,7 @@ public:
 
     /* Make all the elements of the matrix be a new value, when pos = 0
      * Otherwise, the elements before pos will not changed
-     * pos should be less than or equal with size() */
+     * pos should be less than or equal to size() */
     void fill(const value_type &value, const size_t &pos = 0);
 
     /* Calculate number ^ (*this), and store the result in output
@@ -187,7 +187,7 @@ public:
     bool antisymmetric() const;
 
 private:
-    /* Allocate memory for _date, and update _shape with shape */
+    /* Allocate memory for _data, and update _shape with shape */
     inline void allocateMemory(const Shape &shape);
 
     std::unique_ptr<value_type[]> _data;

--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -2,7 +2,7 @@
 
 namespace mca {
 void ThreadPool::resize(size_t newSize) {
-    // if the new size is equal with the old one, do nothing
+    // if the new size is equal to the old one, do nothing
     if (newSize == size()) { return; }
 
     clear();

--- a/test/src/matrix_test.cpp
+++ b/test/src/matrix_test.cpp
@@ -37,12 +37,12 @@ TEST(TestMatrix, constructors) {
     // default constructor
     Matrix<int> m;
     ASSERT_EQ(m.shape(), Shape(0, 0));
-    ASSERT_EQ(m.dataPtr(), nullptr);
+    ASSERT_EQ(m.data(), nullptr);
 
     // construct a matrix with a specified value
     Matrix<int> m1(Shape{3, 3}, -1);
     ASSERT_EQ(m1.shape(), Shape(3, 3));
-    ASSERT_NE(m1.dataPtr(), nullptr);
+    ASSERT_NE(m1.data(), nullptr);
     for (size_t i = 0; i < m1.rows(); i++) {
         for (size_t j = 0; j < m1.columns(); j++) { ASSERT_EQ(m1.get(i, j), -1); }
     }
@@ -50,7 +50,7 @@ TEST(TestMatrix, constructors) {
     // construct from a std::initializer_list
     Matrix<int> m2({{-1, -1, -1}, {-1, -1, -1}});
     ASSERT_EQ(m2.shape(), Shape(2, 3));
-    ASSERT_NE(m2.dataPtr(), nullptr);
+    ASSERT_NE(m2.data(), nullptr);
     for (size_t i = 0; i < m2.rows(); i++) {
         for (size_t j = 0; j < m2.columns(); j++) { ASSERT_EQ(m2.get(i, j), -1); }
     }
@@ -91,12 +91,12 @@ TEST(TestMatrix, constructors) {
 TEST(TestMatrix, assignments) {
     Matrix<int> m;
     ASSERT_EQ(m.shape(), Shape(0, 0));
-    ASSERT_EQ(m.dataPtr(), nullptr);
+    ASSERT_EQ(m.data(), nullptr);
 
     // move assignment from Matrix<int>
     m = Matrix<int>(Shape{3, 3}, 1);
     ASSERT_EQ(m.shape(), Shape(3, 3));
-    ASSERT_NE(m.dataPtr(), nullptr);
+    ASSERT_NE(m.data(), nullptr);
     for (size_t i = 0; i < m.rows(); i++) {
         for (size_t j = 0; j < m.columns(); j++) { ASSERT_EQ(m.get(i, j), 1); }
     }
@@ -110,7 +110,7 @@ TEST(TestMatrix, assignments) {
     Matrix<int> newN(Shape{3, 3}, 1);
     m = newN;
     ASSERT_EQ(m.shape(), Shape(3, 3));
-    ASSERT_NE(m.dataPtr(), nullptr);
+    ASSERT_NE(m.data(), nullptr);
     for (size_t i = 0; i < m.rows(); i++) {
         for (size_t j = 0; j < m.columns(); j++) { ASSERT_EQ(m.get(i, j), 1); }
     }

--- a/test/src/multi_thread_matrix_test.cpp
+++ b/test/src/multi_thread_matrix_test.cpp
@@ -438,8 +438,8 @@ TEST_F(TestMatrixMultiThread, assignmentFromInitializerList) {
     ASSERT_EQ(singleOutput, multiOutput);
     ASSERT_EQ(a.shape(), Shape(0, 0));
     ASSERT_EQ(b.shape(), Shape(2, 0));
-    ASSERT_EQ(a.dataPtr(), nullptr);
-    ASSERT_EQ(b.dataPtr(), nullptr);
+    ASSERT_EQ(a.data(), nullptr);
+    ASSERT_EQ(b.data(), nullptr);
 }
 
 TEST_F(TestMatrixMultiThread, assignmentFromVector) {
@@ -450,8 +450,8 @@ TEST_F(TestMatrixMultiThread, assignmentFromVector) {
 
     ASSERT_EQ(a.shape(), Shape(0, 0));
     ASSERT_EQ(b.shape(), Shape(2, 0));
-    ASSERT_EQ(a.dataPtr(), nullptr);
-    ASSERT_EQ(b.dataPtr(), nullptr);
+    ASSERT_EQ(a.data(), nullptr);
+    ASSERT_EQ(b.data(), nullptr);
 }
 
 TEST_F(TestMatrixMultiThread, transpose) {


### PR DESCRIPTION
We find that the capacity variable will cause memory wastes, when creating a hulk matrix then using copy assignment to copy a small matrix. So we now remove the capacity to make sure the memory used to stored data are equal with the data's size. See https://github.com/Kaiser-Yang/matrix-calculation-accelerator/issues/98.

Add a method called allocateMemory to re-ues codes. See https://github.com/Kaiser-Yang/matrix-calculation-accelerator/issues/107.