### PR TITLE
Add iterators and some member types

### DIFF
--- a/src/include/mca/__mca_internal/matrix_declaration.h
+++ b/src/include/mca/__mca_internal/matrix_declaration.h
@@ -1,7 +1,10 @@
 #ifndef MCA_MATRIX_DECLARATION_H
 #define MCA_MATRIX_DECLARATION_H
+
+#include <memory>
+
 namespace mca {
-template <class ELEMENT_TYPE = double>
+template <class T>
 class Matrix;
 }  // namespace mca
 #endif

--- a/src/include/mca/__mca_internal/single_thread_matrix_calculation.h
+++ b/src/include/mca/__mca_internal/single_thread_matrix_calculation.h
@@ -26,8 +26,8 @@ template <class Number, class T, class O, class = std::enable_if_t<!is_matrix_v<
 void numberPowSingleThread(const Number &number,
                            const Matrix<T> &a,
                            Matrix<O> &output,
-                           const size_t &pos,
-                           const size_t &len);
+                           const std::size_t &pos,
+                           const std::size_t &len);
 
 /* Calculate a ^ number, and store the result in output
  * This will only calculate the a^number[pos: pos + len] in the matrix
@@ -46,8 +46,8 @@ template <class T, class Number, class O, class = std::enable_if_t<!is_matrix_v<
 void powNumberSingleThread(const Matrix<T> &a,
                            const Number &number,
                            Matrix<O> &output,
-                           const size_t &pos,
-                           const size_t &len);
+                           const std::size_t &pos,
+                           const std::size_t &len);
 
 /* Check if the elements of the sub-matrix of a are all less than the sub-matrix of b's
  * This will only check the a[pos:pos+len] with b[pos:pos+len]
@@ -57,8 +57,8 @@ void powNumberSingleThread(const Matrix<T> &a,
 template <class T1, class T2>
 bool lessSingleThread(const Matrix<T1> &a,
                       const Matrix<T2> &b,
-                      const size_t &pos,
-                      const size_t &len,
+                      const std::size_t &pos,
+                      const std::size_t &len,
                       const double &eps = 1e-100);
 
 /* Check if the elements of the sub-matrix of a are all equal to the sub-matrix of b's
@@ -67,8 +67,8 @@ bool lessSingleThread(const Matrix<T1> &a,
 template <class T1, class T2>
 bool equalSingleThread(const Matrix<T1> &a,
                        const Matrix<T2> &b,
-                       const size_t &pos,
-                       const size_t &len,
+                       const std::size_t &pos,
+                       const std::size_t &len,
                        const double &eps = 1e-100);
 
 /* Check if the elements of the sub-matrix of a are all less than or equal to the sub-matrix of
@@ -79,8 +79,8 @@ bool equalSingleThread(const Matrix<T1> &a,
 template <class T1, class T2>
 bool lessEqualSingleThread(const Matrix<T1> &a,
                            const Matrix<T2> &b,
-                           const size_t &pos,
-                           const size_t &len,
+                           const std::size_t &pos,
+                           const std::size_t &len,
                            const double &eps = 1e-100);
 
 /* Check if the elements of the sub-matrix of a are all greater than the sub-matrix of b's
@@ -91,8 +91,8 @@ bool lessEqualSingleThread(const Matrix<T1> &a,
 template <class T1, class T2>
 bool greaterSingleThread(const Matrix<T1> &a,
                          const Matrix<T2> &b,
-                         const size_t &pos,
-                         const size_t &len,
+                         const std::size_t &pos,
+                         const std::size_t &len,
                          const double &eps = 1e-100);
 
 /* Check if the elements of the sub-matrix of a are all greater than or equal to the sub-matrix of
@@ -102,8 +102,8 @@ bool greaterSingleThread(const Matrix<T1> &a,
 template <class T1, class T2>
 bool greaterEqualSingleThread(const Matrix<T1> &a,
                               const Matrix<T2> &b,
-                              const size_t &pos,
-                              const size_t &len,
+                              const std::size_t &pos,
+                              const std::size_t &len,
                               const double &eps = 1e-100);
 
 /* Check if any element of the sub-matrix of a is not equal to the sub-matrix of b's
@@ -113,8 +113,8 @@ bool greaterEqualSingleThread(const Matrix<T1> &a,
 template <class T1, class T2>
 bool notEqualSingleThread(const Matrix<T1> &a,
                           const Matrix<T2> &b,
-                          const size_t &pos,
-                          const size_t &len,
+                          const std::size_t &pos,
+                          const std::size_t &len,
                           const double &eps = 1e-100);
 
 /* Calculate a + b, and store the result in output
@@ -135,8 +135,8 @@ template <class T1, class T2, class O>
 void addSingleThread(const Matrix<T1> &a,
                      const Matrix<T2> &b,
                      Matrix<O> &output,
-                     const size_t &pos,
-                     const size_t &len);
+                     const std::size_t &pos,
+                     const std::size_t &len);
 
 /* Calculate a - b, and store the result in output
  * This will only calculate the a-b[pos:pos+len]
@@ -156,8 +156,8 @@ template <class T1, class T2, class O>
 void subtractSingleThread(const Matrix<T1> &a,
                           const Matrix<T2> &b,
                           Matrix<O> &output,
-                          const size_t &pos,
-                          const size_t &len);
+                          const std::size_t &pos,
+                          const std::size_t &len);
 
 /* Calculate a * b, and store the result in output
  * This will only calculate the a*b[pos:pos+len]
@@ -170,8 +170,8 @@ template <class T1, class T2, class O>
 void multiplySingleThread(const Matrix<T1> &a,
                           const Matrix<T2> &b,
                           Matrix<O> &output,
-                          const size_t &pos,
-                          const size_t &len);
+                          const std::size_t &pos,
+                          const std::size_t &len);
 
 /* Calculate number + a, and store the result in output
  * This will only calculate the number+a[pos:pos+len]
@@ -189,8 +189,8 @@ template <class Number, class T, class O, class = std::enable_if_t<!is_matrix_v<
 void addSingleThread(const Number &number,
                      const Matrix<T> &a,
                      Matrix<O> &output,
-                     const size_t &pos,
-                     const size_t &len);
+                     const std::size_t &pos,
+                     const std::size_t &len);
 
 /* Calculate number - a, and store the result in output
  * This will only calculate the number-a[pos:pos+len]
@@ -208,8 +208,8 @@ template <class Number, class T, class O, class = std::enable_if_t<!is_matrix_v<
 void subtractSingleThread(const Number &number,
                           const Matrix<T> &a,
                           Matrix<O> &output,
-                          const size_t &pos,
-                          const size_t &len);
+                          const std::size_t &pos,
+                          const std::size_t &len);
 
 /* Calculate a - number, and store the result in output
  * This will only calculate the a[pos:pos+len]-number
@@ -227,8 +227,8 @@ template <class T, class Number, class O, class = std::enable_if_t<!is_matrix_v<
 void subtractSingleThread(const Matrix<T> &a,
                           const Number &number,
                           Matrix<O> &output,
-                          const size_t &pos,
-                          const size_t &len);
+                          const std::size_t &pos,
+                          const std::size_t &len);
 
 /* Calculate number * a, and store the result in output
  * This will only calculate the number*a[pos:pos+len]
@@ -246,8 +246,8 @@ template <class Number, class T, class O, class = std::enable_if_t<!is_matrix_v<
 void multiplySingleThread(const Number &number,
                           const Matrix<T> &a,
                           Matrix<O> &output,
-                          const size_t &pos,
-                          const size_t &len);
+                          const std::size_t &pos,
+                          const std::size_t &len);
 
 /* Calculate a / number, and store the result in output
  * This will only calculate the a[pos:pos+len]/number
@@ -265,8 +265,8 @@ template <class T, class Number, class O, class = std::enable_if_t<!is_matrix_v<
 void divideSingleThread(const Matrix<T> &a,
                         const Number &number,
                         Matrix<O> &output,
-                        const size_t &pos,
-                        const size_t &len);
+                        const std::size_t &pos,
+                        const std::size_t &len);
 
 /* Calculate number / a, and store the result in output
  * This will only calculate the number+a[sx:sx+shape.rows][sy:sy+shape+shape.columns]
@@ -285,8 +285,8 @@ template <class Number, class T, class O, class = std::enable_if_t<!is_matrix_v<
 void divideSingleThread(const Number &number,
                         const Matrix<T> &a,
                         Matrix<O> &output,
-                        const size_t &pos,
-                        const size_t &len);
+                        const std::size_t &pos,
+                        const std::size_t &len);
 
 /* Transpose a matrix, and store the result in output
  * This will only get the transposed output[pos:pos+len]
@@ -306,8 +306,8 @@ void divideSingleThread(const Number &number,
 template <class T>
 void transposeSingleThread(const Matrix<T> &a,
                            Matrix<T> &output,
-                           const size_t &pos,
-                           const size_t &len);
+                           const std::size_t &pos,
+                           const std::size_t &len);
 
 /* Check whether or not rows of matrix are symmetric
  * pos: start position from the first element which will be used
@@ -322,8 +322,8 @@ void transposeSingleThread(const Matrix<T> &a,
  *              return: true */
 template <class T>
 bool symmetricSingleThread(const Matrix<T> &a,
-                           const size_t &pos,
-                           const size_t &len,
+                           const std::size_t &pos,
+                           const std::size_t &len,
                            const double &eps = 1e-100);
 
 /* Check whether or not rows of matrix are antisymmetric
@@ -339,8 +339,8 @@ bool symmetricSingleThread(const Matrix<T> &a,
  *              return: true */
 template <class T>
 bool antisymmetricSingleThread(const Matrix<T> &a,
-                               const size_t &pos,
-                               const size_t &len,
+                               const std::size_t &pos,
+                               const std::size_t &len,
                                const double &eps = 1e-100);
 
 // Those below are the implementations
@@ -348,12 +348,12 @@ template <class Number, class T, class O, class>
 void numberPowSingleThread(const Number &number,
                            const Matrix<T> &a,
                            Matrix<O> &output,
-                           const size_t &pos,
-                           const size_t &len) {
+                           const std::size_t &pos,
+                           const std::size_t &len) {
     assert(a.shape() == output.shape());
     assert(pos + len <= a.size());
     using CommonType = std::common_type_t<Number, T, O>;
-    for (size_t i = pos; i < pos + len; i++) {
+    for (std::size_t i = pos; i < pos + len; i++) {
         output[i] = static_cast<O>(
             std::pow(static_cast<CommonType>(number), static_cast<CommonType>(a[i])));
     }
@@ -363,12 +363,12 @@ template <class T, class Number, class O, class>
 void powNumberSingleThread(const Matrix<T> &a,
                            const Number &number,
                            Matrix<O> &output,
-                           const size_t &pos,
-                           const size_t &len) {
+                           const std::size_t &pos,
+                           const std::size_t &len) {
     assert(a.shape() == output.shape());
     assert(pos + len <= a.size());
     using CommonType = std::common_type_t<Number, T, O>;
-    for (size_t i = pos; i < pos + len; i++) {
+    for (std::size_t i = pos; i < pos + len; i++) {
         output[i] = static_cast<O>(
             std::pow(static_cast<CommonType>(a[i]), static_cast<CommonType>(number)));
     }
@@ -377,13 +377,13 @@ void powNumberSingleThread(const Matrix<T> &a,
 template <class T1, class T2>
 bool lessSingleThread(const Matrix<T1> &a,
                       const Matrix<T2> &b,
-                      const size_t &pos,
-                      const size_t &len,
+                      const std::size_t &pos,
+                      const std::size_t &len,
                       const double &eps) {
     assert(a.shape() == b.shape());
     assert(pos + len <= a.size());
     using CommonType = std::common_type_t<T1, T2>;
-    for (size_t i = pos; i < pos + len; i++) {
+    for (std::size_t i = pos; i < pos + len; i++) {
         if (std::is_floating_point_v<CommonType> &&
             static_cast<CommonType>(a[i]) - static_cast<CommonType>(b[i]) >= -eps) {
             return false;
@@ -399,13 +399,13 @@ bool lessSingleThread(const Matrix<T1> &a,
 template <class T1, class T2>
 bool equalSingleThread(const Matrix<T1> &a,
                        const Matrix<T2> &b,
-                       const size_t &pos,
-                       const size_t &len,
+                       const std::size_t &pos,
+                       const std::size_t &len,
                        const double &eps) {
     assert(a.shape() == b.shape());
     assert(pos + len <= a.size());
     using CommonType = std::common_type_t<T1, T2>;
-    for (size_t i = pos; i < pos + len; i++) {
+    for (std::size_t i = pos; i < pos + len; i++) {
         if (std::is_floating_point_v<CommonType> &&
             std::fabs(static_cast<CommonType>(a[i]) - static_cast<CommonType>(b[i])) > eps) {
             return false;
@@ -421,13 +421,13 @@ bool equalSingleThread(const Matrix<T1> &a,
 template <class T1, class T2>
 bool lessEqualSingleThread(const Matrix<T1> &a,
                            const Matrix<T2> &b,
-                           const size_t &pos,
-                           const size_t &len,
+                           const std::size_t &pos,
+                           const std::size_t &len,
                            const double &eps) {
     assert(a.shape() == b.shape());
     assert(pos + len <= a.size());
     using CommonType = std::common_type_t<T1, T2>;
-    for (size_t i = pos; i < pos + len; i++) {
+    for (std::size_t i = pos; i < pos + len; i++) {
         if (std::is_floating_point_v<CommonType> &&
             static_cast<CommonType>(a[i]) - static_cast<CommonType>(b[i]) > eps) {
             return false;
@@ -443,13 +443,13 @@ bool lessEqualSingleThread(const Matrix<T1> &a,
 template <class T1, class T2>
 bool greaterSingleThread(const Matrix<T1> &a,
                          const Matrix<T2> &b,
-                         const size_t &pos,
-                         const size_t &len,
+                         const std::size_t &pos,
+                         const std::size_t &len,
                          const double &eps) {
     assert(a.shape() == b.shape());
     assert(pos + len <= a.size());
     using CommonType = std::common_type_t<T1, T2>;
-    for (size_t i = pos; i < pos + len; i++) {
+    for (std::size_t i = pos; i < pos + len; i++) {
         if (std::is_floating_point_v<CommonType> &&
             (static_cast<CommonType>(a[i]) - static_cast<CommonType>(b[i]) < eps ||
              fabs(static_cast<CommonType>(a[i]) - static_cast<CommonType>(b[i])) <= eps)) {
@@ -466,13 +466,13 @@ bool greaterSingleThread(const Matrix<T1> &a,
 template <class T1, class T2>
 bool greaterEqualSingleThread(const Matrix<T1> &a,
                               const Matrix<T2> &b,
-                              const size_t &pos,
-                              const size_t &len,
+                              const std::size_t &pos,
+                              const std::size_t &len,
                               const double &eps) {
     assert(a.shape() == b.shape());
     assert(pos + len <= a.size());
     using CommonType = std::common_type_t<T1, T2>;
-    for (size_t i = pos; i < pos + len; i++) {
+    for (std::size_t i = pos; i < pos + len; i++) {
         if (std::is_floating_point_v<CommonType> &&
             static_cast<CommonType>(a[i]) - static_cast<CommonType>(b[i]) < -eps) {
             return false;
@@ -488,13 +488,13 @@ bool greaterEqualSingleThread(const Matrix<T1> &a,
 template <class T1, class T2>
 bool notEqualSingleThread(const Matrix<T1> &a,
                           const Matrix<T2> &b,
-                          const size_t &pos,
-                          const size_t &len,
+                          const std::size_t &pos,
+                          const std::size_t &len,
                           const double &eps) {
     assert(a.shape() == b.shape());
     assert(pos + len <= a.size());
     using CommonType = std::common_type_t<T1, T2>;
-    for (size_t i = pos; i < pos + len; i++) {
+    for (std::size_t i = pos; i < pos + len; i++) {
         if (std::is_floating_point_v<CommonType> &&
             std::fabs(static_cast<CommonType>(a[i]) - static_cast<CommonType>(b[i])) <= eps) {
             return false;
@@ -511,12 +511,12 @@ template <class Number, class T, class O, class>
 void multiplySingleThread(const Number &number,
                           const Matrix<T> &a,
                           Matrix<O> &output,
-                          const size_t &pos,
-                          const size_t &len) {
+                          const std::size_t &pos,
+                          const std::size_t &len) {
     assert(a.shape() == output.shape());
     assert(pos + len <= a.size());
     using CommonType = std::common_type_t<Number, T, O>;
-    for (size_t i = pos; i < pos + len; i++)
+    for (std::size_t i = pos; i < pos + len; i++)
         output[i] = static_cast<O>(static_cast<CommonType>(a[i]) * static_cast<CommonType>(number));
 }
 
@@ -524,13 +524,13 @@ template <class T1, class T2, class O>
 void addSingleThread(const Matrix<T1> &a,
                      const Matrix<T2> &b,
                      Matrix<O> &output,
-                     const size_t &pos,
-                     const size_t &len) {
+                     const std::size_t &pos,
+                     const std::size_t &len) {
     assert(a.shape() == b.shape());
     assert(a.shape() == output.shape());
     assert(pos + len <= a.size());
     using CommonType = std::common_type_t<T1, T2, O>;
-    for (size_t i = pos; i < pos + len; i++) {
+    for (std::size_t i = pos; i < pos + len; i++) {
         output[i] = static_cast<O>(static_cast<CommonType>(a[i]) + static_cast<CommonType>(b[i]));
     }
 }
@@ -539,12 +539,12 @@ template <class T1, class T2, class O>
 void subtractSingleThread(const Matrix<T1> &a,
                           const Matrix<T2> &b,
                           Matrix<O> &output,
-                          const size_t &pos,
-                          const size_t &len) {
+                          const std::size_t &pos,
+                          const std::size_t &len) {
     assert(a.shape() == b.shape());
     assert(pos + len <= a.size());
     using CommonType = std::common_type_t<T1, T2, O>;
-    for (size_t i = pos; i < pos + len; i++) {
+    for (std::size_t i = pos; i < pos + len; i++) {
         output[i] = static_cast<O>(static_cast<CommonType>(a[i]) - static_cast<CommonType>(b[i]));
     }
 }
@@ -553,20 +553,20 @@ template <class T1, class T2, class O>
 void multiplySingleThread(const Matrix<T1> &a,
                           const Matrix<T2> &b,
                           Matrix<O> &output,
-                          const size_t &pos,
-                          const size_t &len) {
+                          const std::size_t &pos,
+                          const std::size_t &len) {
     assert(reinterpret_cast<const void *>(&a) != reinterpret_cast<const void *>(&output));
     assert(a.columns() == b.rows());
     assert(a.rows() == output.rows());
     assert(b.columns() == output.columns());
     assert(pos + len <= output.size());
     using CommonType = std::common_type_t<T1, T2, O>;
-    size_t i = 0, j = 0;
-    for (size_t t = pos; t < pos + len; t++) {
+    std::size_t i = 0, j = 0;
+    for (std::size_t t = pos; t < pos + len; t++) {
         i                = t / output.columns();
         j                = t % output.columns();
         output.get(i, j) = O();
-        for (size_t k = 0; k < a.columns(); k++) {
+        for (std::size_t k = 0; k < a.columns(); k++) {
             // clang-format off
             output.get(i, j) = static_cast<O>(static_cast<CommonType>(output.get(i, j)) +
                                               static_cast<CommonType>(a.get(i, k)) *
@@ -580,12 +580,12 @@ template <class Number, class T, class O, class>
 void addSingleThread(const Number &number,
                      const Matrix<T> &a,
                      Matrix<O> &output,
-                     const size_t &pos,
-                     const size_t &len) {
+                     const std::size_t &pos,
+                     const std::size_t &len) {
     assert(a.shape() == output.shape());
     assert(pos + len <= a.size());
     using CommonType = std::common_type_t<Number, T, O>;
-    for (size_t i = pos; i < pos + len; i++)
+    for (std::size_t i = pos; i < pos + len; i++)
         output[i] = static_cast<O>(static_cast<CommonType>(number) + static_cast<CommonType>(a[i]));
 }
 
@@ -593,12 +593,12 @@ template <class Number, class T, class O, class>
 void subtractSingleThread(const Number &number,
                           const Matrix<T> &a,
                           Matrix<O> &output,
-                          const size_t &pos,
-                          const size_t &len) {
+                          const std::size_t &pos,
+                          const std::size_t &len) {
     assert(a.shape() == output.shape());
     assert(pos + len <= a.size());
     using CommonType = std::common_type_t<Number, T, O>;
-    for (size_t i = pos; i < pos + len; i++)
+    for (std::size_t i = pos; i < pos + len; i++)
         output[i] = static_cast<O>(static_cast<CommonType>(number) - static_cast<CommonType>(a[i]));
 }
 
@@ -606,12 +606,12 @@ template <class T, class Number, class O, class>
 void subtractSingleThread(const Matrix<T> &a,
                           const Number &number,
                           Matrix<O> &output,
-                          const size_t &pos,
-                          const size_t &len) {
+                          const std::size_t &pos,
+                          const std::size_t &len) {
     assert(a.shape() == output.shape());
     assert(pos + len <= a.size());
     using CommonType = std::common_type_t<Number, T, O>;
-    for (size_t i = pos; i < pos + len; i++)
+    for (std::size_t i = pos; i < pos + len; i++)
         output[i] = static_cast<O>(static_cast<CommonType>(a[i]) - static_cast<CommonType>(number));
 }
 
@@ -619,12 +619,12 @@ template <class T, class Number, class O, class>
 void divideSingleThread(const Matrix<T> &a,
                         const Number &number,
                         Matrix<O> &output,
-                        const size_t &pos,
-                        const size_t &len) {
+                        const std::size_t &pos,
+                        const std::size_t &len) {
     assert(a.shape() == output.shape());
     assert(pos + len <= a.size());
     using CommonType = std::common_type_t<Number, T, O>;
-    for (size_t i = pos; i < pos + len; i++)
+    for (std::size_t i = pos; i < pos + len; i++)
         output[i] = static_cast<O>(static_cast<CommonType>(a[i]) / static_cast<CommonType>(number));
 }
 
@@ -632,12 +632,12 @@ template <class Number, class T, class O, class>
 void divideSingleThread(const Number &number,
                         const Matrix<T> &a,
                         Matrix<O> &output,
-                        const size_t &pos,
-                        const size_t &len) {
+                        const std::size_t &pos,
+                        const std::size_t &len) {
     assert(a.shape() == output.shape());
     assert(pos + len <= a.size());
     using CommonType = std::common_type_t<Number, T, O>;
-    for (size_t i = pos; i < pos + len; i++) {
+    for (std::size_t i = pos; i < pos + len; i++) {
         output[i] = static_cast<O>(static_cast<CommonType>(number) / static_cast<CommonType>(a[i]));
     }
 }
@@ -645,14 +645,14 @@ void divideSingleThread(const Number &number,
 template <class T>
 void transposeSingleThread(const Matrix<T> &a,
                            Matrix<T> &output,
-                           const size_t &pos,
-                           const size_t &len) {
+                           const std::size_t &pos,
+                           const std::size_t &len) {
     assert(reinterpret_cast<const void *>(&a) != reinterpret_cast<const void *>(&output));
     assert(a.rows() == output.columns());
     assert(a.columns() == output.rows());
     assert(pos + len <= output.size());
-    size_t i = 0, j = 0;
-    for (size_t t = pos; t < pos + len; t++) {
+    std::size_t i = 0, j = 0;
+    for (std::size_t t = pos; t < pos + len; t++) {
         i                = t / output.columns();
         j                = t % output.columns();
         output.get(i, j) = a.get(j, i);
@@ -661,13 +661,13 @@ void transposeSingleThread(const Matrix<T> &a,
 
 template <class T>
 bool symmetricSingleThread(const Matrix<T> &a,
-                           const size_t &pos,
-                           const size_t &len,
+                           const std::size_t &pos,
+                           const std::size_t &len,
                            const double &eps) {
     assert(a.rows() == a.columns());
     assert(pos + len <= (a.size() - a.rows()) / 2);
-    size_t i = 0, j = 0, k = 0;
-    for (size_t t = pos; t < pos + len; t++) {
+    std::size_t i = 0, j = 0, k = 0;
+    for (std::size_t t = pos; t < pos + len; t++) {
         k = std::ceil((-1 + std::sqrt(1 + 4 * a.rows() * a.rows() - 4 * a.rows() - 8 * t) / 2.0));
         i = a.rows() - 1 - k;
         j = a.rows() - (a.rows() * (a.rows() - 1) / 2 - k * (k - 1) / 2);
@@ -682,13 +682,13 @@ bool symmetricSingleThread(const Matrix<T> &a,
 
 template <class T>
 bool antisymmetricSingleThread(const Matrix<T> &a,
-                               const size_t &pos,
-                               const size_t &len,
+                               const std::size_t &pos,
+                               const std::size_t &len,
                                const double &eps) {
     assert(a.rows() == a.columns());
     assert(pos + len <= (a.size() - a.rows()) / 2);
-    size_t i = 0, j = 0, k = 0;
-    for (size_t t = pos; t < pos + len; t++) {
+    std::size_t i = 0, j = 0, k = 0;
+    for (std::size_t t = pos; t < pos + len; t++) {
         k = std::ceil((-1 + std::sqrt(1 + 4 * a.rows() * a.rows() - 4 * a.rows() - 8 * t) / 2.0));
         i = a.rows() - 1 - k;
         j = a.rows() - (a.rows() * (a.rows() - 1) / 2 - k * (k - 1) / 2);

--- a/src/include/mca/__mca_internal/thread_pool.h
+++ b/src/include/mca/__mca_internal/thread_pool.h
@@ -17,16 +17,17 @@ namespace mca {
  * synchronizations are needed when more than one thread operate the same object of the class */
 class ThreadPool {
 public:
+    using size_type = std::size_t;
     /* size is the size of the thread pool */
-    inline ThreadPool(size_t size = 0);
+    inline ThreadPool(size_type size = 0) { resize(size); }
 
     /* set a new size, and this will clear the task queue
      * this will wait for all the running threads finish their current tasks, then stop them
      * and create new threads */
-    void resize(size_t newSize);
+    void resize(size_type newSize);
 
     /* the size of the thread pool */
-    inline size_t size();
+    inline size_type size() { return threadQueue.size(); }
 
     /* add a task to the thread pool
      * this will return a std::future
@@ -42,12 +43,12 @@ public:
     void clear();
 
     /* the destructor will stop all the threads */
-    inline ~ThreadPool();
+    inline ~ThreadPool() { clear(); }
 
 private:
     std::vector<std::queue<std::function<void()>>> taskQueue;
     std::queue<std::thread> threadQueue;
-    size_t i{0};
+    size_type i{0};
     std::atomic<bool> stopped{false};
 };
 
@@ -62,12 +63,6 @@ auto ThreadPool::addTask(Function &&func, Args &&...args)
     i = (i + 1) % size();
     return taskPtr->get_future();
 }
-
-inline ThreadPool::ThreadPool(size_t size) { resize(size); }
-
-inline size_t ThreadPool::size() { return threadQueue.size(); }
-
-inline ThreadPool::~ThreadPool() { clear(); }
 }  // namespace mca
 
 #endif

--- a/src/include/mca/diag.h
+++ b/src/include/mca/diag.h
@@ -10,6 +10,8 @@ namespace mca {
 template <class Container>
 class _Diag {
 public:
+    using size_type = std::size_t;
+
     _Diag() = delete;
 
     _Diag(_Diag &&other) noexcept = delete;
@@ -18,32 +20,19 @@ public:
     _Diag &operator=(const _Diag &) = delete;
     _Diag &operator=(_Diag &&)      = delete;
 
-    inline explicit _Diag(const Container &other);
-    inline explicit _Diag(Container &&other);
+    inline explicit _Diag(const Container &other) : _diagRef(other) {}
+    inline explicit _Diag(Container &&other) : _diag(std::move(other)), _diagRef(_diag) {}
 
-    inline const typename Container::value_type &operator[](const size_t &i) const;
-    inline size_t size() const;
+    inline const typename Container::value_type &operator[](const size_type &i) const {
+        return std::data(_diagRef)[i];
+    }
+
+    inline size_type size() const noexcept { return _diagRef.size(); }
 
 private:
     const Container &_diagRef;
     Container _diag;
 };
-
-template <class Container>
-_Diag<Container>::_Diag(const Container &_diag) : _diagRef(_diag) {}
-
-template <class Container>
-inline _Diag<Container>::_Diag(Container &&_diag) : _diag(std::move(_diag)), _diagRef(_diag) {}
-
-template <class Container>
-inline const typename Container::value_type &_Diag<Container>::operator[](const size_t &i) const {
-    return std::data(_diagRef)[i];
-}
-
-template <class Container>
-inline size_t _Diag<Container>::size() const {
-    return _diagRef.size();
-}
 
 template <class Container>
 inline _Diag<std::decay_t<Container>> Diag(Container &&container) {

--- a/src/include/mca/mca.h
+++ b/src/include/mca/mca.h
@@ -14,33 +14,34 @@
 #include "shape.h"
 
 namespace mca {
+using size_type = std::size_t;
 /* Initialize the mca, before using mca, you must call init
  * If you don't call init, mca will run in single thread mode
  * threadNum is how many threads will be used when calculating
  * limit is the minimal quantity of a thread's calculation
  * eps is the epsilon when comparing matrices whose elements' types are floating number */
-extern void init(const size_t &threadNum = std::thread::hardware_concurrency() - 1,
-                 const size_t &limit     = 623,
-                 const double &eps       = 1e-100);
+extern void init(const size_type &threadNum = std::thread::hardware_concurrency() - 1,
+                 const size_type &limit     = 623,
+                 const double &eps          = 1e-100);
 
 /* Set how many threads will be used when calculating */
-extern void setThreadNum(const size_t &threadNum);
+extern void setThreadNum(const size_type &threadNum);
 
 /* Set the minimal quantity of a thread's calculation
  * Make sure every sub-thread's calculation is no less than limit
  * When the rest part is less than limit, the main thread will calculate the rest
  * NOTE: if you want to calculate with single thread, you can set the limit with
- *       std::numeric_limits<size_t>::max() */
-extern void setLimit(const size_t &limit);
+ *       std::numeric_limits<size_type>::max() */
+extern void setLimit(const size_type &limit);
 
 /* set the epsilon used for comparing floating numbers */
 extern void setEpsilon(const double &eps);
 
 /* return current thread number */
-extern size_t threadNum();
+extern size_type threadNum();
 
 /* return current limit */
-extern size_t limit();
+extern size_type limit();
 
 /* return current epsilon */
 extern double epsilon();
@@ -48,7 +49,7 @@ extern double epsilon();
 /* return trhead pool object, this should not called by the usrs
  * this is for developers */
 extern ThreadPool &threadPool();
-inline std::pair<size_t, size_t> threadCalculationTaskNum(const size_t &total);
+inline std::pair<size_type, size_type> threadCalculationTaskNum(const size_type &total);
 
 /* Check if matrix a and matrix b are equal using multi-thread
  * return false when a's shape is not same with b's shape
@@ -326,7 +327,7 @@ bool operator==(const Matrix<T1> &a, const Matrix<T2> &b) {
     }
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<bool>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([start = i * res.first, &a, &b, len = res.first]() -> bool {
                 return equalSingleThread(a, b, start, len, epsilon());
@@ -346,7 +347,7 @@ bool operator!=(const Matrix<T1> &a, const Matrix<T2> &b) {
     }
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<bool>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([start = i * res.first, &a, &b, len = res.first]() -> bool {
                 return notEqualSingleThread(a, b, start, len, epsilon());
@@ -366,7 +367,7 @@ bool operator<(const Matrix<T1> &a, const Matrix<T2> &b) {
     }
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<bool>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([start = i * res.first, &a, &b, len = res.first]() -> bool {
                 return lessSingleThread(a, b, start, len, epsilon());
@@ -386,7 +387,7 @@ bool operator<=(const Matrix<T1> &a, const Matrix<T2> &b) {
     }
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<bool>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([start = i * res.first, &a, &b, len = res.first]() -> bool {
                 return lessEqualSingleThread(a, b, start, len, epsilon());
@@ -406,7 +407,7 @@ bool operator>(const Matrix<T1> &a, const Matrix<T2> &b) {
     }
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<bool>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([start = i * res.first, &a, &b, len = res.first]() -> bool {
                 return greaterSingleThread(a, b, start, len, epsilon());
@@ -426,7 +427,7 @@ bool operator>=(const Matrix<T1> &a, const Matrix<T2> &b) {
     }
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<bool>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([start = i * res.first, &a, &b, len = res.first]() -> bool {
                 return greaterEqualSingleThread(a, b, start, len, epsilon());
@@ -449,7 +450,7 @@ Matrix<std::common_type_t<T1, T2>> operator+(const Matrix<T1> &a, const Matrix<T
     }
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<void>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([&result, start = i * res.first, &a, &b, len = res.first]() {
                 addSingleThread(a, b, result, start, len);
@@ -472,7 +473,7 @@ Matrix<std::common_type_t<T1, T2>> operator-(const Matrix<T1> &a, const Matrix<T
     }
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<void>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([&result, start = i * res.first, &a, &b, len = res.first]() {
                 subtractSingleThread(a, b, result, start, len);
@@ -495,7 +496,7 @@ Matrix<std::common_type_t<T1, T2>> operator*(const Matrix<T1> &a, const Matrix<T
     }
     auto res = threadCalculationTaskNum(result.size());
     std::vector<std::future<void>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([&result, start = i * res.first, &a, &b, len = res.first]() {
                 multiplySingleThread(a, b, result, start, len);
@@ -519,7 +520,7 @@ Matrix<std::common_type_t<T, Number>> operator+(const Matrix<T> &a, const Number
     // threadCalculation and taskNum
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<void>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([&result, start = i * res.first, &a, &number, len = res.first]() {
                 addSingleThread(number, a, result, start, len);
@@ -550,7 +551,7 @@ Matrix<std::common_type_t<T, Number>> operator-(const Matrix<T> &a, const Number
     // threadCalculation and taskNum
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<void>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([&result, start = i * res.first, &a, &number, len = res.first]() {
                 subtractSingleThread(a, number, result, start, len);
@@ -576,7 +577,7 @@ Matrix<std::common_type_t<T, Number>> operator-(const Number &number, const Matr
     // threadCalculation and taskNum
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<void>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([&result, start = i * res.first, &a, &number, len = res.first]() {
                 subtractSingleThread(number, a, result, start, len);
@@ -607,7 +608,7 @@ Matrix<std::common_type_t<T, Number>> operator*(const Number &number, const Matr
     // threadCalculation and taskNum
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<void>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([&result, start = i * res.first, &a, &number, len = res.first]() {
                 multiplySingleThread(number, a, result, start, len);
@@ -633,7 +634,7 @@ Matrix<std::common_type_t<T, Number>> operator/(const Matrix<T> &a, const Number
     // threadCalculation and taskNum
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<void>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([&result, start = i * res.first, &a, &number, len = res.first]() {
                 divideSingleThread(a, number, result, start, len);
@@ -659,7 +660,7 @@ Matrix<std::common_type_t<T, Number>> operator/(const Number &number, const Matr
     // threadCalculation and taskNum
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<void>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([&result, start = i * res.first, &a, &number, len = res.first]() {
                 divideSingleThread(number, a, result, start, len);
@@ -682,7 +683,7 @@ void operator+=(Matrix<T1> &a, const Matrix<T2> &b) {
     }
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<void>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] = threadPool().addTask([start = i * res.first, &a, &b, len = res.first]() {
             addSingleThread(a, b, a, start, len);
         });
@@ -700,7 +701,7 @@ void operator-=(Matrix<T1> &a, const Matrix<T2> &b) {
     }
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<void>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] = threadPool().addTask([start = i * res.first, &a, &b, len = res.first]() {
             subtractSingleThread(a, b, a, start, len);
         });
@@ -721,7 +722,7 @@ void operator*=(Matrix<T1> &a, const Matrix<T2> &b) {
     }
     auto res = threadCalculationTaskNum(result.size());
     std::vector<std::future<void>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([&result, start = i * res.first, &a, &b, len = res.first]() {
                 multiplySingleThread(a, b, result, start, len);
@@ -743,7 +744,7 @@ void operator+=(Matrix<T> &a, const Number &number) {
     // threadCalculation and taskNum
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<void>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([start = i * res.first, &a, &number, len = res.first]() {
                 addSingleThread(number, a, a, start, len);
@@ -771,7 +772,7 @@ void operator-=(Matrix<T> &a, const Number &number) {
     // threadCalculation and taskNum
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<void>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([start = i * res.first, &a, &number, len = res.first]() {
                 subtractSingleThread(a, number, a, start, len);
@@ -795,7 +796,7 @@ void operator-=(const Number &number, Matrix<T> &a) {
     // threadCalculation and taskNum
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<void>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([start = i * res.first, &a, &number, len = res.first]() {
                 subtractSingleThread(number, a, a, start, len);
@@ -823,7 +824,7 @@ void operator*=(const Number &number, Matrix<T> &a) {
     // threadCalculation and taskNum
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<void>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([start = i * res.first, &a, &number, len = res.first]() {
                 multiplySingleThread(number, a, a, start, len);
@@ -847,7 +848,7 @@ void operator/=(Matrix<T> &a, const Number &number) {
     // threadCalculation and taskNum
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<void>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([start = i * res.first, &a, &number, len = res.first]() {
                 divideSingleThread(a, number, a, start, len);
@@ -870,7 +871,7 @@ void operator/=(const Number &number, Matrix<T> &a) {
     // threadCalculation and taskNum
     auto res = threadCalculationTaskNum(a.size());
     std::vector<std::future<void>> returnValue(res.second - 1);
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([start = i * res.first, &a, &number, len = res.first]() {
                 divideSingleThread(number, a, a, start, len);
@@ -908,7 +909,7 @@ void transpose(const Matrix<T> &a, Matrix<O> &output) {
     std::vector<std::future<void>> returnValue(res.second - 1);
 
     // assign task for every sub-thread
-    for (size_t i = 0; i < res.second - 1; i++) {
+    for (size_type i = 0; i < res.second - 1; i++) {
         returnValue[i] =
             threadPool().addTask([&a, start = i * res.first, len = res.first, &output]() {
                 transposeSingleThread(a, output, start, len);
@@ -923,9 +924,9 @@ void transpose(const Matrix<T> &a, Matrix<O> &output) {
     for (auto &item : returnValue) { item.get(); }
 }
 
-inline std::pair<size_t, size_t> threadCalculationTaskNum(const size_t &total) {
-    size_t threadCalculation = std::max(total / (threadNum() + 1), limit());
-    size_t taskNum           = total / threadCalculation;
+inline std::pair<size_type, size_type> threadCalculationTaskNum(const size_type &total) {
+    size_type threadCalculation = std::max(total / (threadNum() + 1), limit());
+    size_type taskNum           = total / threadCalculation;
     if (total % threadCalculation > 0) { taskNum++; }
     return {threadCalculation, taskNum};
 }

--- a/src/include/mca/shape.h
+++ b/src/include/mca/shape.h
@@ -5,29 +5,22 @@
 
 namespace mca {
 struct Shape {
-    size_t rows    = 0;
-    size_t columns = 0;
+    using size_type   = std::size_t;
+    size_type rows    = 0;
+    size_type columns = 0;
 
     inline Shape() = default;
 
-    inline explicit Shape(size_t rows, size_t columns);
+    inline explicit Shape(const size_type &rows, const size_type &columns)
+        : rows(rows), columns(columns) {}
 
-    inline bool operator==(const Shape &other) const;
+    inline bool operator==(const Shape &other) const noexcept {
+        return rows == other.rows && columns == other.columns;
+    }
 
-    inline bool operator!=(const Shape &other) const;
+    inline bool operator!=(const Shape &other) const noexcept { return !(*this == other); }
 
-    inline size_t size() const;
+    inline size_type size() const noexcept { return rows * columns; };
 };
-
-inline Shape::Shape(size_t rows, size_t columns) : rows(rows), columns(columns) {}
-
-inline bool Shape::operator==(const Shape &other) const {
-    return rows == other.rows && columns == other.columns;
-}
-
-inline bool Shape::operator!=(const Shape &other) const { return !(*this == other); }
-
-inline size_t Shape::size() const { return rows * columns; }
-
 }  // namespace mca
 #endif

--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -1,7 +1,7 @@
 #include "mca/__mca_internal/thread_pool.h"
 
 namespace mca {
-void ThreadPool::resize(size_t newSize) {
+void ThreadPool::resize(size_type newSize) {
     // if the new size is equal to the old one, do nothing
     if (newSize == size()) { return; }
 
@@ -13,7 +13,7 @@ void ThreadPool::resize(size_t newSize) {
         taskQueue.emplace_back(std::queue<std::function<void()>>());
     }
     assert(size() == 0);
-    for (size_t i = 0; i < newSize; i++) {
+    for (size_type i = 0; i < newSize; i++) {
         threadQueue.emplace([this, id = size()]() {
             std::function<void()> task;
             while (!stopped.load(std::memory_order_relaxed)) {

--- a/test/src/different_type_test.cpp
+++ b/test/src/different_type_test.cpp
@@ -7,12 +7,12 @@ namespace mca {
 namespace test {
 class TestDifferentType : public testing::Test {
 protected:
-    Matrix<> doubleMatrix, doubleOutput, doubleResult;
+    Matrix<double> doubleMatrix, doubleOutput, doubleResult;
     Matrix<int> intMatrix, intOutput, intResult;
 
     void SetUp() override {
-        doubleMatrix = Matrix<>(Shape{3, 3}, -1.);
-        doubleOutput = Matrix<>(Shape{3, 3}, 0.);
+        doubleMatrix = Matrix<double>(Shape{3, 3}, -1.);
+        doubleOutput = Matrix<double>(Shape{3, 3}, 0.);
         intMatrix    = Matrix<int>(Shape{3, 3}, -1);
         intOutput    = Matrix<int>(Shape{3, 3}, 0);
     }
@@ -31,123 +31,123 @@ TEST_F(TestDifferentType, differentTypeComparison) {
 
 TEST_F(TestDifferentType, differentTypeCalculation) {
     addSingleThread(intMatrix, doubleMatrix, doubleOutput, 0, intMatrix.size());
-    doubleResult = Matrix<>(Shape{3, 3}, -2.);
+    doubleResult = Matrix<double>(Shape{3, 3}, -2.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     addSingleThread(intMatrix, doubleMatrix, intOutput, 0, intMatrix.size());
     intResult = Matrix<int>(Shape{3, 3}, -2);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
 
     subtractSingleThread(intMatrix, doubleMatrix, doubleOutput, 0, intMatrix.size());
-    doubleResult = Matrix<>(Shape{3, 3}, 0);
+    doubleResult = Matrix<double>(Shape{3, 3}, 0);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     subtractSingleThread(intMatrix, doubleMatrix, intOutput, 0, intMatrix.size());
     intResult = Matrix<int>(Shape{3, 3}, 0);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
 
     multiplySingleThread(intMatrix, doubleMatrix, doubleOutput, 0, intMatrix.size());
-    doubleResult = Matrix<>(Shape{3, 3}, 3.);
+    doubleResult = Matrix<double>(Shape{3, 3}, 3.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     multiplySingleThread(intMatrix, doubleMatrix, intOutput, 0, intMatrix.size());
     intResult = Matrix<int>(Shape{3, 3}, 3);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
 
     powNumberSingleThread(doubleMatrix, 2, doubleOutput, 0, doubleMatrix.size());
-    doubleResult = Matrix<>(Shape{3, 3}, 1.);
+    doubleResult = Matrix<double>(Shape{3, 3}, 1.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     powNumberSingleThread(doubleMatrix, 2, intOutput, 0, doubleMatrix.size());
     intResult = Matrix<int>(Shape{3, 3}, 1);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
     powNumberSingleThread(intMatrix, 2, doubleOutput, 0, intMatrix.size());
-    doubleResult = Matrix<>(Shape{3, 3}, 1.);
+    doubleResult = Matrix<double>(Shape{3, 3}, 1.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     powNumberSingleThread(intMatrix, 2, intOutput, 0, intMatrix.size());
     intResult = Matrix<int>(Shape{3, 3}, 1);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
 
     numberPowSingleThread(2, doubleMatrix, doubleOutput, 0, doubleMatrix.size());
-    doubleResult = Matrix<>(Shape{3, 3}, std::pow(2, -1));
+    doubleResult = Matrix<double>(Shape{3, 3}, std::pow(2, -1));
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     numberPowSingleThread(2, doubleMatrix, intOutput, 0, doubleMatrix.size());
     intResult = Matrix<int>(Shape{3, 3}, static_cast<int>(std::pow(2, -1)));
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
     numberPowSingleThread(2, intMatrix, doubleOutput, 0, intMatrix.size());
-    doubleResult = Matrix<>(Shape{3, 3}, std::pow(2, -1));
+    doubleResult = Matrix<double>(Shape{3, 3}, std::pow(2, -1));
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     numberPowSingleThread(2, intMatrix, intOutput, 0, intMatrix.size());
     intResult = Matrix<int>(Shape{3, 3}, static_cast<int>(std::pow(2, -1)));
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
 
     addSingleThread(1, doubleMatrix, doubleOutput, 0, doubleMatrix.size());
-    doubleResult = Matrix<>(Shape{3, 3}, 0.);
+    doubleResult = Matrix<double>(Shape{3, 3}, 0.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     addSingleThread(1, doubleMatrix, intOutput, 0, doubleMatrix.size());
     intResult = Matrix<int>(Shape{3, 3}, 0);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
     addSingleThread(1, intMatrix, doubleOutput, 0, intMatrix.size());
-    doubleResult = Matrix<>(Shape{3, 3}, 0.);
+    doubleResult = Matrix<double>(Shape{3, 3}, 0.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     addSingleThread(1, intMatrix, intOutput, 0, intMatrix.size());
     intResult = Matrix<int>(Shape{3, 3}, 0);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
 
     subtractSingleThread(1, doubleMatrix, doubleOutput, 0, doubleMatrix.size());
-    doubleResult = Matrix<>(Shape{3, 3}, 2.);
+    doubleResult = Matrix<double>(Shape{3, 3}, 2.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     subtractSingleThread(1, doubleMatrix, intOutput, 0, doubleMatrix.size());
     intResult = Matrix<int>(Shape{3, 3}, 2);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
     subtractSingleThread(1, intMatrix, doubleOutput, 0, intMatrix.size());
-    doubleResult = Matrix<>(Shape{3, 3}, 2.);
+    doubleResult = Matrix<double>(Shape{3, 3}, 2.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     subtractSingleThread(1, intMatrix, intOutput, 0, intMatrix.size());
     intResult = Matrix<int>(Shape{3, 3}, 2);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
     subtractSingleThread(doubleMatrix, 1, doubleOutput, 0, doubleMatrix.size());
-    doubleResult = Matrix<>(Shape{3, 3}, -2.);
+    doubleResult = Matrix<double>(Shape{3, 3}, -2.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     subtractSingleThread(doubleMatrix, 1, intOutput, 0, doubleMatrix.size());
     intResult = Matrix<int>(Shape{3, 3}, -2);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
     subtractSingleThread(intMatrix, 1, doubleOutput, 0, intMatrix.size());
-    doubleResult = Matrix<>(Shape{3, 3}, -2.);
+    doubleResult = Matrix<double>(Shape{3, 3}, -2.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     subtractSingleThread(intMatrix, 1, intOutput, 0, intMatrix.size());
     intResult = Matrix<int>(Shape{3, 3}, -2);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
 
     multiplySingleThread(-1, doubleMatrix, doubleOutput, 0, doubleMatrix.size());
-    doubleResult = Matrix<>(Shape{3, 3}, 1.);
+    doubleResult = Matrix<double>(Shape{3, 3}, 1.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     multiplySingleThread(-1, doubleMatrix, intOutput, 0, doubleMatrix.size());
     intResult = Matrix<int>(Shape{3, 3}, 1);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
     multiplySingleThread(-1, intMatrix, doubleOutput, 0, intMatrix.size());
-    doubleResult = Matrix<>(Shape{3, 3}, 1.);
+    doubleResult = Matrix<double>(Shape{3, 3}, 1.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     multiplySingleThread(-1, intMatrix, intOutput, 0, intMatrix.size());
     intResult = Matrix<int>(Shape{3, 3}, 1);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
 
     divideSingleThread(-1, doubleMatrix, doubleOutput, 0, doubleMatrix.size());
-    doubleResult = Matrix<>(Shape{3, 3}, 1.);
+    doubleResult = Matrix<double>(Shape{3, 3}, 1.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     divideSingleThread(-1, doubleMatrix, intOutput, 0, doubleMatrix.size());
     intResult = Matrix<int>(Shape{3, 3}, 1);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
     divideSingleThread(-1, intMatrix, doubleOutput, 0, intMatrix.size());
-    doubleResult = Matrix<>(Shape{3, 3}, 1.);
+    doubleResult = Matrix<double>(Shape{3, 3}, 1.);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     divideSingleThread(-1, intMatrix, intOutput, 0, intMatrix.size());
     intResult = Matrix<int>(Shape{3, 3}, 1);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
     divideSingleThread(doubleMatrix, 3, doubleOutput, 0, doubleMatrix.size());
-    doubleResult = Matrix<>(Shape{3, 3}, -1. / 3);
+    doubleResult = Matrix<double>(Shape{3, 3}, -1. / 3);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     divideSingleThread(doubleMatrix, 3, intOutput, 0, doubleMatrix.size());
     intResult = Matrix<int>(Shape{3, 3}, -1. / 3);
     ASSERT_TRUE(equalSingleThread(intOutput, intResult, 0, intOutput.size()));
     divideSingleThread(intMatrix, 3, doubleOutput, 0, intMatrix.size());
-    doubleResult = Matrix<>(Shape{3, 3}, -1. / 3);
+    doubleResult = Matrix<double>(Shape{3, 3}, -1. / 3);
     ASSERT_TRUE(equalSingleThread(doubleOutput, doubleResult, 0, doubleOutput.size()));
     divideSingleThread(intMatrix, 3, intOutput, 0, intMatrix.size());
     intResult = Matrix<int>(Shape{3, 3}, -1. / 3);

--- a/test/src/multi_thread_matrix_calculation_test.cpp
+++ b/test/src/multi_thread_matrix_calculation_test.cpp
@@ -23,7 +23,7 @@ protected:
     Shape rectangleShape1{1000, 1210};
     Shape rectangleShape2{1210, 1000};
     std::default_random_engine generator;
-    Matrix<> singleOutput, multiOutput, a, b, c, mulA, mulB;
+    Matrix<double> singleOutput, multiOutput, a, b, c, mulA, mulB;
 
     void SetUp() override { generator.seed(time(nullptr)); }
 
@@ -32,7 +32,7 @@ protected:
 
 TEST_F(TestMultiThreadCalculation, numAddMatrix) {
     auto value = generator() % MAX_VALUE, number = generator() % MAX_VALUE;
-    a = Matrix<>(squareShape, value);
+    a = Matrix<double>(squareShape, value);
 
     auto startTime     = high_resolution_clock::now();
     singleOutput       = number + a;
@@ -60,7 +60,7 @@ TEST_F(TestMultiThreadCalculation, numAddMatrix) {
 
 TEST_F(TestMultiThreadCalculation, matrixAddNum) {
     auto value = generator() % MAX_VALUE, number = generator() % MAX_VALUE;
-    a = Matrix<>(squareShape, value);
+    a = Matrix<double>(squareShape, value);
 
     auto startTime     = high_resolution_clock::now();
     singleOutput       = a + number;
@@ -89,7 +89,7 @@ TEST_F(TestMultiThreadCalculation, matrixAddNum) {
 TEST_F(TestMultiThreadCalculation, matrixSelfAddNum) {
     auto value = generator() % MAX_VALUE, number = generator() % MAX_VALUE;
 
-    singleOutput = multiOutput = Matrix<>(squareShape, value);
+    singleOutput = multiOutput = Matrix<double>(squareShape, value);
 
     // first use addSingleThread to get the single mode time
     auto startTime = high_resolution_clock::now();
@@ -119,7 +119,7 @@ TEST_F(TestMultiThreadCalculation, matrixSelfAddNum) {
 TEST_F(TestMultiThreadCalculation, numSelfAddMatrix) {
     auto value = generator() % MAX_VALUE, number = generator() % MAX_VALUE;
 
-    singleOutput = multiOutput = Matrix<>(squareShape, value);
+    singleOutput = multiOutput = Matrix<double>(squareShape, value);
 
     // first use addSingleThread to get the single mode time
     auto startTime = high_resolution_clock::now();
@@ -149,8 +149,8 @@ TEST_F(TestMultiThreadCalculation, numSelfAddMatrix) {
 TEST_F(TestMultiThreadCalculation, matrixSubtractMatrix) {
     auto value1 = generator() % MAX_VALUE, value2 = generator() % MAX_VALUE;
 
-    a = Matrix<>(squareShape, value1);
-    b = Matrix<>(squareShape, value2);
+    a = Matrix<double>(squareShape, value1);
+    b = Matrix<double>(squareShape, value2);
 
     auto startTime     = high_resolution_clock::now();
     singleOutput       = a - b;
@@ -179,9 +179,9 @@ TEST_F(TestMultiThreadCalculation, matrixSubtractMatrix) {
 TEST_F(TestMultiThreadCalculation, matrixSelfSubtractMatrix) {
     auto value1 = generator() % MAX_VALUE, value2 = generator() % MAX_VALUE;
 
-    singleOutput = multiOutput = Matrix<>(squareShape, value1);
+    singleOutput = multiOutput = Matrix<double>(squareShape, value1);
 
-    a = Matrix<>(squareShape, value2);
+    a = Matrix<double>(squareShape, value2);
 
     auto startTime = high_resolution_clock::now();
     singleOutput -= a;
@@ -210,8 +210,8 @@ TEST_F(TestMultiThreadCalculation, matrixSelfSubtractMatrix) {
 TEST_F(TestMultiThreadCalculation, matrixAddMatrix) {
     auto value1 = generator() % MAX_VALUE, value2 = generator() % MAX_VALUE;
 
-    a = Matrix<>(squareShape, value1);
-    b = Matrix<>(squareShape, value2);
+    a = Matrix<double>(squareShape, value1);
+    b = Matrix<double>(squareShape, value2);
 
     auto startTime     = high_resolution_clock::now();
     singleOutput       = a + b;
@@ -240,9 +240,9 @@ TEST_F(TestMultiThreadCalculation, matrixAddMatrix) {
 TEST_F(TestMultiThreadCalculation, matrixSelfAddMatrix) {
     auto value1 = generator() % MAX_VALUE, value2 = generator() % MAX_VALUE;
 
-    singleOutput = multiOutput = Matrix<>(squareShape, value1);
+    singleOutput = multiOutput = Matrix<double>(squareShape, value1);
 
-    a = Matrix<>(squareShape, value2);
+    a = Matrix<double>(squareShape, value2);
 
     auto startTime = high_resolution_clock::now();
     singleOutput += a;
@@ -271,8 +271,8 @@ TEST_F(TestMultiThreadCalculation, matrixSelfAddMatrix) {
 TEST_F(TestMultiThreadCalculation, matrixMultiplyMatrix) {
     auto value1 = generator() % MAX_VALUE, value2 = generator() % MAX_VALUE;
 
-    mulA = Matrix<>(mul1Shape, value1);
-    mulB = Matrix<>(mul2Shape, value2);
+    mulA = Matrix<double>(mul1Shape, value1);
+    mulB = Matrix<double>(mul2Shape, value2);
 
     auto startTime     = high_resolution_clock::now();
     singleOutput       = mulA * mulB;
@@ -301,9 +301,9 @@ TEST_F(TestMultiThreadCalculation, matrixMultiplyMatrix) {
 TEST_F(TestMultiThreadCalculation, matrixSelfMultiplyMatrix) {
     auto value1 = generator() % MAX_VALUE, value2 = generator() % MAX_VALUE;
 
-    singleOutput = multiOutput = Matrix<>(mul1Shape, value1);
+    singleOutput = multiOutput = Matrix<double>(mul1Shape, value1);
 
-    mulA = Matrix<>(mul2Shape, value2);
+    mulA = Matrix<double>(mul2Shape, value2);
 
     auto startTime = high_resolution_clock::now();
     singleOutput *= mulA;
@@ -332,9 +332,9 @@ TEST_F(TestMultiThreadCalculation, matrixSelfMultiplyMatrix) {
 TEST_F(TestMultiThreadCalculation, matrixLessEqualMatrix) {
     auto value1 = generator() % MAX_VALUE, value2 = generator() % MAX_VALUE;
 
-    a = Matrix<>(squareShape, value1);
-    b = Matrix<>(squareShape, value2);
-    c = Matrix<>(smallShape, value1);
+    a = Matrix<double>(squareShape, value1);
+    b = Matrix<double>(squareShape, value2);
+    c = Matrix<double>(smallShape, value1);
 
     // judgement of different shapes
     ASSERT_FALSE(a <= c);
@@ -363,7 +363,7 @@ TEST_F(TestMultiThreadCalculation, matrixLessEqualMatrix) {
 
 TEST_F(TestMultiThreadCalculation, numSubtractMatrix) {
     auto value = generator() % MAX_VALUE, number = generator() % MAX_VALUE;
-    a = Matrix<>(squareShape, value);
+    a = Matrix<double>(squareShape, value);
 
     auto startTime     = high_resolution_clock::now();
     singleOutput       = number - a;
@@ -391,7 +391,7 @@ TEST_F(TestMultiThreadCalculation, numSubtractMatrix) {
 
 TEST_F(TestMultiThreadCalculation, matrixDivideNum) {
     auto value = generator() % MAX_VALUE, number = generator() % MAX_VALUE + 1;
-    a = Matrix<>(squareShape, value);
+    a = Matrix<double>(squareShape, value);
 
     auto startTime     = high_resolution_clock::now();
     singleOutput       = a / number;
@@ -420,7 +420,7 @@ TEST_F(TestMultiThreadCalculation, matrixDivideNum) {
 TEST_F(TestMultiThreadCalculation, matrixSelfDivideNum) {
     auto value = generator() % MAX_VALUE, number = generator() % MAX_VALUE + 1;
 
-    singleOutput = multiOutput = Matrix<>(squareShape, value);
+    singleOutput = multiOutput = Matrix<double>(squareShape, value);
 
     // first use addSingleThread to get the single mode time
     auto startTime = high_resolution_clock::now();
@@ -450,7 +450,7 @@ TEST_F(TestMultiThreadCalculation, matrixSelfDivideNum) {
 TEST_F(TestMultiThreadCalculation, numSelfSubtractMatrix) {
     auto value = generator() % MAX_VALUE, number = generator() % MAX_VALUE;
 
-    singleOutput = multiOutput = Matrix<>(squareShape, value);
+    singleOutput = multiOutput = Matrix<double>(squareShape, value);
 
     // first use addSingleThread to get the single mode time
     auto startTime = high_resolution_clock::now();
@@ -480,9 +480,9 @@ TEST_F(TestMultiThreadCalculation, numSelfSubtractMatrix) {
 TEST_F(TestMultiThreadCalculation, matrixGreaterEqualMatrix) {
     auto value1 = generator() % MAX_VALUE, value2 = generator() % MAX_VALUE;
 
-    a = Matrix<>(squareShape, value1);
-    b = Matrix<>(squareShape, value2);
-    c = Matrix<>(smallShape, value1);
+    a = Matrix<double>(squareShape, value1);
+    b = Matrix<double>(squareShape, value2);
+    c = Matrix<double>(smallShape, value1);
 
     // judgement of different shapes
     ASSERT_FALSE(a <= c);
@@ -511,7 +511,7 @@ TEST_F(TestMultiThreadCalculation, matrixGreaterEqualMatrix) {
 
 TEST_F(TestMultiThreadCalculation, matrixSubtractNum) {
     auto value = generator() % MAX_VALUE, number = generator() % MAX_VALUE;
-    a = Matrix<>(squareShape, value);
+    a = Matrix<double>(squareShape, value);
 
     auto startTime     = high_resolution_clock::now();
     singleOutput       = a - number;
@@ -539,7 +539,7 @@ TEST_F(TestMultiThreadCalculation, matrixSubtractNum) {
 
 TEST_F(TestMultiThreadCalculation, numDivideMatrix) {
     auto value = generator() % MAX_VALUE + 1, number = generator() % MAX_VALUE;
-    a = Matrix<>(squareShape, value);
+    a = Matrix<double>(squareShape, value);
 
     auto startTime     = high_resolution_clock::now();
     singleOutput       = number / a;
@@ -567,7 +567,7 @@ TEST_F(TestMultiThreadCalculation, numDivideMatrix) {
 
 TEST_F(TestMultiThreadCalculation, matrixSelfSubtractNum) {
     auto value = generator() % MAX_VALUE, number = generator() % MAX_VALUE;
-    singleOutput = multiOutput = Matrix<>(squareShape, value);
+    singleOutput = multiOutput = Matrix<double>(squareShape, value);
 
     auto startTime = high_resolution_clock::now();
     singleOutput -= number;
@@ -595,7 +595,7 @@ TEST_F(TestMultiThreadCalculation, matrixSelfSubtractNum) {
 
 TEST_F(TestMultiThreadCalculation, numSelfDivideMatrix) {
     auto value = generator() % MAX_VALUE + 1, number = generator() % MAX_VALUE;
-    singleOutput = multiOutput = Matrix<>(squareShape, value);
+    singleOutput = multiOutput = Matrix<double>(squareShape, value);
 
     auto startTime = high_resolution_clock::now();
     number /= singleOutput;
@@ -622,7 +622,7 @@ TEST_F(TestMultiThreadCalculation, numSelfDivideMatrix) {
 }
 
 TEST_F(TestMultiThreadCalculation, transposeMatrix) {
-    singleOutput = multiOutput = Matrix<>(rectangleShape1);
+    singleOutput = multiOutput = Matrix<double>(rectangleShape1);
     for (size_t i = 0; i < singleOutput.rows(); i++) {
         for (size_t j = 0; j < singleOutput.columns(); j++) {
             singleOutput.get(i, j) = multiOutput.get(i, j) = generator() % MAX_VALUE;
@@ -653,9 +653,9 @@ TEST_F(TestMultiThreadCalculation, transposeMatrix) {
 }
 
 TEST_F(TestMultiThreadCalculation, transposeMatrixToOutput) {
-    singleOutput = multiOutput = Matrix<>(rectangleShape2);
+    singleOutput = multiOutput = Matrix<double>(rectangleShape2);
 
-    a = Matrix<>(rectangleShape1);
+    a = Matrix<double>(rectangleShape1);
 
     for (size_t i = 0; i < a.rows(); i++) {
         for (size_t j = 0; j < a.columns(); j++) { a.get(i, j) = generator() % MAX_VALUE; }
@@ -688,9 +688,9 @@ TEST_F(TestMultiThreadCalculation, transposeMatrixToOutput) {
 TEST_F(TestMultiThreadCalculation, matrixLessMatrix) {
     auto value1 = generator() % MAX_VALUE, value2 = generator() % MAX_VALUE;
 
-    a = Matrix<>(squareShape, value1);
-    b = Matrix<>(squareShape, value2);
-    c = Matrix<>(smallShape, value1);
+    a = Matrix<double>(squareShape, value1);
+    b = Matrix<double>(squareShape, value2);
+    c = Matrix<double>(smallShape, value1);
 
     // judgement of different shapes
     ASSERT_FALSE(a < c);
@@ -720,9 +720,9 @@ TEST_F(TestMultiThreadCalculation, matrixLessMatrix) {
 TEST_F(TestMultiThreadCalculation, matrixEqualMatrix) {
     auto value1 = generator() % MAX_VALUE, value2 = generator() % MAX_VALUE;
 
-    a = Matrix<>(squareShape, value1);
-    b = Matrix<>(squareShape, value2);
-    c = Matrix<>(smallShape, value1);
+    a = Matrix<double>(squareShape, value1);
+    b = Matrix<double>(squareShape, value2);
+    c = Matrix<double>(smallShape, value1);
 
     // judgement of different shapes
     ASSERT_FALSE(a == c);
@@ -761,9 +761,9 @@ TEST_F(TestMultiThreadCalculation, matrixEqualMatrix) {
 TEST_F(TestMultiThreadCalculation, matrixNotEqualMatrix) {
     auto value1 = generator() % MAX_VALUE, value2 = generator() % MAX_VALUE;
 
-    a = Matrix<>(squareShape, value1);
-    b = Matrix<>(squareShape, value2);
-    c = Matrix<>(smallShape, value1);
+    a = Matrix<double>(squareShape, value1);
+    b = Matrix<double>(squareShape, value2);
+    c = Matrix<double>(smallShape, value1);
 
     // judgement of different shapes
     ASSERT_NE(a, c);
@@ -802,9 +802,9 @@ TEST_F(TestMultiThreadCalculation, matrixNotEqualMatrix) {
 TEST_F(TestMultiThreadCalculation, matrixGreaterMatrix) {
     auto value1 = generator() % MAX_VALUE, value2 = generator() % MAX_VALUE;
 
-    a = Matrix<>(squareShape, value1);
-    b = Matrix<>(squareShape, value2);
-    c = Matrix<>(smallShape, value1);
+    a = Matrix<double>(squareShape, value1);
+    b = Matrix<double>(squareShape, value2);
+    c = Matrix<double>(smallShape, value1);
 
     // judgement of different shapes
     ASSERT_FALSE(a > c);
@@ -833,7 +833,7 @@ TEST_F(TestMultiThreadCalculation, matrixGreaterMatrix) {
 
 TEST_F(TestMultiThreadCalculation, matrixMultiplyNum) {
     auto value = generator() % MAX_VALUE, number = generator() % MAX_VALUE;
-    a = Matrix<>(squareShape, value);
+    a = Matrix<double>(squareShape, value);
 
     auto startTime     = high_resolution_clock::now();
     singleOutput       = a * number;
@@ -861,7 +861,7 @@ TEST_F(TestMultiThreadCalculation, matrixMultiplyNum) {
 
 TEST_F(TestMultiThreadCalculation, numMultiplyMatrix) {
     auto value = generator() % MAX_VALUE, number = generator() % MAX_VALUE;
-    a = Matrix<>(squareShape, value);
+    a = Matrix<double>(squareShape, value);
 
     auto startTime     = high_resolution_clock::now();
     singleOutput       = number * a;
@@ -890,7 +890,7 @@ TEST_F(TestMultiThreadCalculation, numMultiplyMatrix) {
 TEST_F(TestMultiThreadCalculation, numSelfMultiplyMatrix) {
     auto value = generator() % MAX_VALUE, number = generator() % MAX_VALUE;
 
-    singleOutput = multiOutput = Matrix<>(squareShape, value);
+    singleOutput = multiOutput = Matrix<double>(squareShape, value);
 
     // first use addSingleThread to get the single mode time
     auto startTime = high_resolution_clock::now();
@@ -920,7 +920,7 @@ TEST_F(TestMultiThreadCalculation, numSelfMultiplyMatrix) {
 TEST_F(TestMultiThreadCalculation, matrixSelfMultiplyNum) {
     auto value = generator() % MAX_VALUE, number = generator() % MAX_VALUE;
 
-    singleOutput = multiOutput = Matrix<>(squareShape, value);
+    singleOutput = multiOutput = Matrix<double>(squareShape, value);
 
     // first use addSingleThread to get the single mode time
     auto startTime = high_resolution_clock::now();

--- a/test/src/same_address_test.cpp
+++ b/test/src/same_address_test.cpp
@@ -9,57 +9,57 @@ namespace mca {
 namespace test {
 class TestSameAddress : public testing::Test {
 protected:
-    Matrix<> a, b;
-    void SetUp() override { a = b = Matrix<>({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}); }
+    Matrix<double> a, b;
+    void SetUp() override { a = b = Matrix<double>({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}); }
 
     void TearDown() override {}
 };
 
 TEST_F(TestSameAddress, powNumber) {
     powNumberSingleThread(a, 2, a, 0, a.size());
-    Matrix<> result{{1, 2 * 2, 3 * 3}, {4 * 4, 5 * 5, 6 * 6}, {7 * 7, 8 * 8, 9 * 9}};
+    Matrix<double> result{{1, 2 * 2, 3 * 3}, {4 * 4, 5 * 5, 6 * 6}, {7 * 7, 8 * 8, 9 * 9}};
     ASSERT_TRUE(equalSingleThread(a, result, 0, a.size()));
 }
 
 TEST_F(TestSameAddress, numberPow) {
     numberPowSingleThread(2, a, a, 0, a.size());
-    Matrix<> result({{std::pow(2, 1), std::pow(2, 2), std::pow(2, 3)},
-                     {std::pow(2, 4), std::pow(2, 5), std::pow(2, 6)},
-                     {std::pow(2, 7), std::pow(2, 8), std::pow(2, 9)}});
+    Matrix<double> result({{std::pow(2, 1), std::pow(2, 2), std::pow(2, 3)},
+                           {std::pow(2, 4), std::pow(2, 5), std::pow(2, 6)},
+                           {std::pow(2, 7), std::pow(2, 8), std::pow(2, 9)}});
     ASSERT_TRUE(equalSingleThread(a, result, 0, a.size()));
 }
 
 TEST_F(TestSameAddress, addNumber) {
     addSingleThread(2, a, a, 0, a.size());
-    Matrix<> result({{2 + 1, 2 + 2, 2 + 3}, {2 + 4, 2 + 5, 2 + 6}, {2 + 7, 2 + 8, 2 + 9}});
+    Matrix<double> result({{2 + 1, 2 + 2, 2 + 3}, {2 + 4, 2 + 5, 2 + 6}, {2 + 7, 2 + 8, 2 + 9}});
     ASSERT_TRUE(equalSingleThread(a, result, 0, a.size()));
 }
 
 TEST_F(TestSameAddress, subtractNumber) {
     subtractSingleThread(a, 2, a, 0, a.size());
-    Matrix<> result1({{1 - 2, 2 - 2, 3 - 2}, {4 - 2, 5 - 2, 6 - 2}, {7 - 2, 8 - 2, 9 - 2}});
+    Matrix<double> result1({{1 - 2, 2 - 2, 3 - 2}, {4 - 2, 5 - 2, 6 - 2}, {7 - 2, 8 - 2, 9 - 2}});
     subtractSingleThread(2, b, b, 0, b.size());
-    Matrix<> result2({{2 - 1, 2 - 2, 2 - 3}, {2 - 4, 2 - 5, 2 - 6}, {2 - 7, 2 - 8, 2 - 9}});
+    Matrix<double> result2({{2 - 1, 2 - 2, 2 - 3}, {2 - 4, 2 - 5, 2 - 6}, {2 - 7, 2 - 8, 2 - 9}});
     ASSERT_TRUE(equalSingleThread(a, result1, 0, a.size()));
     ASSERT_TRUE(equalSingleThread(b, result2, 0, b.size()));
 }
 
 TEST_F(TestSameAddress, multiplyNumber) {
     multiplySingleThread(2, a, a, 0, a.size());
-    Matrix<> result({{2 * 1, 2 * 2, 2 * 3}, {2 * 4, 2 * 5, 2 * 6}, {2 * 7, 2 * 8, 2 * 9}});
+    Matrix<double> result({{2 * 1, 2 * 2, 2 * 3}, {2 * 4, 2 * 5, 2 * 6}, {2 * 7, 2 * 8, 2 * 9}});
     ASSERT_TRUE(equalSingleThread(a, result, 0, a.size()));
 }
 
 TEST_F(TestSameAddress, divideNumber) {
     divideSingleThread(a, 2, a, 0, a.size());
     // clang-format off
-    Matrix<> result1({{1. / 2, 2. / 2, 3. / 2},
+    Matrix<double> result1({{1. / 2, 2. / 2, 3. / 2},
                       {4. / 2, 5. / 2, 6. / 2},
                       {7. / 2, 8. / 2, 9. / 2}});
     // clang-format on
     divideSingleThread(2, b, b, 0, b.size());
     // clang-format off
-    Matrix<> result2({{2. / 1, 2. / 2, 2. / 3},
+    Matrix<double> result2({{2. / 1, 2. / 2, 2. / 3},
                       {2. / 4, 2. / 5, 2. / 6},
                       {2. / 7, 2. / 8, 2. / 9}});
     // clang-format on
@@ -69,13 +69,13 @@ TEST_F(TestSameAddress, divideNumber) {
 
 TEST_F(TestSameAddress, addMatrix) {
     addSingleThread(a, a, a, 0, a.size());
-    Matrix<> result({{1 + 1, 2 + 2, 3 + 3}, {4 + 4, 5 + 5, 6 + 6}, {7 + 7, 8 + 8, 9 + 9}});
+    Matrix<double> result({{1 + 1, 2 + 2, 3 + 3}, {4 + 4, 5 + 5, 6 + 6}, {7 + 7, 8 + 8, 9 + 9}});
     ASSERT_TRUE(equalSingleThread(a, result, 0, a.size()));
 }
 
 TEST_F(TestSameAddress, subtractMatrix) {
     subtractSingleThread(a, a, a, 0, a.size());
-    Matrix<> result({{1 - 1, 2 - 2, 3 - 3}, {4 - 4, 5 - 5, 6 - 6}, {7 - 7, 8 - 8, 9 - 9}});
+    Matrix<double> result({{1 - 1, 2 - 2, 3 - 3}, {4 - 4, 5 - 5, 6 - 6}, {7 - 7, 8 - 8, 9 - 9}});
     ASSERT_TRUE(equalSingleThread(a, result, 0, a.size()));
 }
 }  // namespace test

--- a/test/src/single_thread_matrix_calculation_test.cpp
+++ b/test/src/single_thread_matrix_calculation_test.cpp
@@ -10,50 +10,51 @@ namespace mca {
 namespace test {
 class TestSingleThreadCalculation : public testing::Test {
 protected:
-    Matrix<> one, negOne, output, a, b, c, d, sym, antisym;
+    Matrix<double> one, negOne, output, a, b, c, d, sym, antisym;
     Matrix<int> e, f;
 
     void SetUp() override {
-        one     = Matrix<>(Shape{3, 3}, 1);
-        negOne  = Matrix<>(Shape{3, 3}, -1);
-        a       = Matrix<>({{0, 0, 0}, {1, 1, 1}, {2, 2, 2}});
-        b       = Matrix<>({{1, 0, 0}, {0, 1, 0}, {0, 0, 1}});
-        c       = Matrix<>({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}});
-        d       = Matrix<>({{0, 0, 0}, {1, 1, 1}, {2, 2, 2}});
-        e       = Matrix<int>({{1, 2, 3}, {2, 3, 4}, {6, 6, 6}});
-        f       = Matrix<int>({{3, 2, 1}, {2, 3, 4}, {6, 6, 6}});
-        sym     = Matrix<>({{1, 2. / 3, 3. / 5}, {4. / 6, 3, 8. / 6}, {1.5 / 2.5, 4. / 3, 5}});
-        antisym = Matrix<>({{1, -2. / 3, -3. / 5}, {4. / 6, 3, -8. / 6}, {1.5 / 2.5, 4. / 3, 5}});
+        one    = Matrix<double>(Shape{3, 3}, 1);
+        negOne = Matrix<double>(Shape{3, 3}, -1);
+        a      = Matrix<double>({{0, 0, 0}, {1, 1, 1}, {2, 2, 2}});
+        b      = Matrix<double>({{1, 0, 0}, {0, 1, 0}, {0, 0, 1}});
+        c      = Matrix<double>({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}});
+        d      = Matrix<double>({{0, 0, 0}, {1, 1, 1}, {2, 2, 2}});
+        e      = Matrix<int>({{1, 2, 3}, {2, 3, 4}, {6, 6, 6}});
+        f      = Matrix<int>({{3, 2, 1}, {2, 3, 4}, {6, 6, 6}});
+        sym    = Matrix<double>({{1, 2. / 3, 3. / 5}, {4. / 6, 3, 8. / 6}, {1.5 / 2.5, 4. / 3, 5}});
+        antisym =
+            Matrix<double>({{1, -2. / 3, -3. / 5}, {4. / 6, 3, -8. / 6}, {1.5 / 2.5, 4. / 3, 5}});
     }
 
     void TearDown() override {}
 };
 
 TEST_F(TestSingleThreadCalculation, powNumberWholeMatrix) {
-    output = Matrix<>(Shape{3, 3}, 0);
+    output = Matrix<double>(Shape{3, 3}, 0);
     powNumberSingleThread(a, 2, output, 0, a.size());
-    Matrix<> result = Matrix<>({{0, 0, 0}, {1, 1, 1}, {4, 4, 4}});
+    Matrix<double> result = Matrix<double>({{0, 0, 0}, {1, 1, 1}, {4, 4, 4}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, powNumberSubMatrix) {
-    output = Matrix<>(Shape{3, 3}, -1);
+    output = Matrix<double>(Shape{3, 3}, -1);
     powNumberSingleThread(c, 2, output, 1, 5);
-    Matrix<> result = Matrix<>({{-1, 4, 9}, {16, 25, 36}, {-1, -1, -1}});
+    Matrix<double> result = Matrix<double>({{-1, 4, 9}, {16, 25, 36}, {-1, -1, -1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, numberPowWholeMatrix) {
-    output = Matrix<>(Shape{3, 3}, 0);
+    output = Matrix<double>(Shape{3, 3}, 0);
     numberPowSingleThread(2, a, output, 0, a.size());
-    Matrix<> result = Matrix<>({{1, 1, 1}, {2, 2, 2}, {4, 4, 4}});
+    Matrix<double> result = Matrix<double>({{1, 1, 1}, {2, 2, 2}, {4, 4, 4}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, numberPowSubMatrix) {
-    output = Matrix<>(Shape{3, 3}, -1);
+    output = Matrix<double>(Shape{3, 3}, -1);
     numberPowSingleThread(2, c, output, 1, 5);
-    Matrix<> result({{-1, 4, 8}, {16, 32, 64}, {-1, -1, -1}});
+    Matrix<double> result({{-1, 4, 8}, {16, 32, 64}, {-1, -1, -1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
@@ -125,85 +126,85 @@ TEST_F(TestSingleThreadCalculation, notEqualSubMatrix) {
 }
 
 TEST_F(TestSingleThreadCalculation, addNumberWholeMatrix) {
-    output = Matrix<>(Shape{3, 3}, -1);
+    output = Matrix<double>(Shape{3, 3}, -1);
     addSingleThread(2, a, output, 0, a.size());
-    Matrix<> result({{2, 2, 2}, {3, 3, 3}, {4, 4, 4}});
+    Matrix<double> result({{2, 2, 2}, {3, 3, 3}, {4, 4, 4}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, addNumberSubMatrix) {
-    output = Matrix<>(Shape{3, 3}, -1);
+    output = Matrix<double>(Shape{3, 3}, -1);
     addSingleThread(2, a, output, 4, 4);
-    Matrix<> result({{-1, -1, -1}, {-1, 3, 3}, {4, 4, -1}});
+    Matrix<double> result({{-1, -1, -1}, {-1, 3, 3}, {4, 4, -1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, subtractNumberWholeMatrix) {
-    output = Matrix<>(Shape{3, 3}, -1);
+    output = Matrix<double>(Shape{3, 3}, -1);
     subtractSingleThread(a, 1, output, 0, a.size());
-    Matrix<> result({{-1, -1, -1}, {0, 0, 0}, {1, 1, 1}});
+    Matrix<double> result({{-1, -1, -1}, {0, 0, 0}, {1, 1, 1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 
     Matrix<int> output2(Shape{3, 3}, -1);
     subtractSingleThread(9, e, output2, 0, a.size());
-    Matrix<> result2({{8, 7, 6}, {7, 6, 5}, {3, 3, 3}});
+    Matrix<double> result2({{8, 7, 6}, {7, 6, 5}, {3, 3, 3}});
     ASSERT_TRUE(equalSingleThread(output2, result2, 0, output2.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, subtractNumberSubMatrix) {
-    output = Matrix<>(Shape{3, 3}, -1);
+    output = Matrix<double>(Shape{3, 3}, -1);
     subtractSingleThread(a, 1, output, 4, 4);
-    Matrix<> result({{-1, -1, -1}, {-1, 0, 0}, {1, 1, -1}});
+    Matrix<double> result({{-1, -1, -1}, {-1, 0, 0}, {1, 1, -1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 
     Matrix<int> output2(Shape{3, 3}, -1);
     subtractSingleThread(9, e, output2, 3, 6);
-    Matrix<> result2({{-1, -1, -1}, {7, 6, 5}, {3, 3, 3}});
+    Matrix<double> result2({{-1, -1, -1}, {7, 6, 5}, {3, 3, 3}});
     ASSERT_TRUE(equalSingleThread(output2, result2, 0, output2.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, multiplyNumberWholeMatrix) {
-    output = Matrix<>(Shape{3, 3}, -1);
+    output = Matrix<double>(Shape{3, 3}, -1);
     multiplySingleThread(3, c, output, 0, c.size());
-    Matrix<> result({{3, 6, 9}, {12, 15, 18}, {21, 24, 27}});
+    Matrix<double> result({{3, 6, 9}, {12, 15, 18}, {21, 24, 27}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, multiplyNumberSubMatrix) {
-    output = Matrix<>(Shape{3, 3}, -1);
+    output = Matrix<double>(Shape{3, 3}, -1);
     multiplySingleThread(3, c, output, 3, 6);
-    Matrix<> result({{-1, -1, -1}, {12, 15, 18}, {21, 24, 27}});
+    Matrix<double> result({{-1, -1, -1}, {12, 15, 18}, {21, 24, 27}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, divideNumberWholeMatrix) {
-    output = Matrix<>(Shape{3, 3}, -1);
+    output = Matrix<double>(Shape{3, 3}, -1);
     divideSingleThread(c, 3, output, 0, c.size());
-    Matrix<> result({{1. / 3, 2. / 3, 1}, {4. / 3, 5. / 3, 2}, {7. / 3, 8. / 3, 3}});
+    Matrix<double> result({{1. / 3, 2. / 3, 1}, {4. / 3, 5. / 3, 2}, {7. / 3, 8. / 3, 3}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 
-    output = Matrix<>(Shape{3, 3}, -1);
+    output = Matrix<double>(Shape{3, 3}, -1);
     divideSingleThread(9, c, output, 0, c.size());
-    Matrix<> result2({{9, 9. / 2, 3}, {9. / 4, 9. / 5, 9. / 6}, {9. / 7, 9. / 8, 1}});
+    Matrix<double> result2({{9, 9. / 2, 3}, {9. / 4, 9. / 5, 9. / 6}, {9. / 7, 9. / 8, 1}});
     ASSERT_TRUE(equalSingleThread(output, result2, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, divideNumberSubMatrix) {
-    output = Matrix<>(Shape{3, 3}, -1);
+    output = Matrix<double>(Shape{3, 3}, -1);
     divideSingleThread(c, 3, output, 3, 6);
-    Matrix<> result({{-1, -1, -1}, {4. / 3, 5. / 3, 2}, {7. / 3, 8. / 3, 3}});
+    Matrix<double> result({{-1, -1, -1}, {4. / 3, 5. / 3, 2}, {7. / 3, 8. / 3, 3}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 
-    output = Matrix<>(Shape{3, 3}, -1);
+    output = Matrix<double>(Shape{3, 3}, -1);
     divideSingleThread(9, c, output, 3, 6);
-    Matrix<> result2({{-1, -1, -1}, {9. / 4, 9. / 5, 9. / 6}, {9. / 7, 9. / 8, 1}});
+    Matrix<double> result2({{-1, -1, -1}, {9. / 4, 9. / 5, 9. / 6}, {9. / 7, 9. / 8, 1}});
     ASSERT_TRUE(equalSingleThread(output, result2, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, addWholeMatrix) {
-    output = Matrix<>(Shape{3, 3}, 0);
+    output = Matrix<double>(Shape{3, 3}, 0);
     addSingleThread(a, b, output, 0, a.size());
-    Matrix<> result({{1, 0, 0}, {1, 2, 1}, {2, 2, 3}});
+    Matrix<double> result({{1, 0, 0}, {1, 2, 1}, {2, 2, 3}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 
     addSingleThread(b, a, output, 0, b.size());
@@ -211,9 +212,9 @@ TEST_F(TestSingleThreadCalculation, addWholeMatrix) {
 }
 
 TEST_F(TestSingleThreadCalculation, addSubMatrix) {
-    output = Matrix<>(Shape{3, 3}, -1);
+    output = Matrix<double>(Shape{3, 3}, -1);
     addSingleThread(a, b, output, 3, 6);
-    Matrix<> result({{-1, -1, -1}, {1, 2, 1}, {2, 2, 3}});
+    Matrix<double> result({{-1, -1, -1}, {1, 2, 1}, {2, 2, 3}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 
     addSingleThread(b, a, output, 3, 6);
@@ -221,60 +222,60 @@ TEST_F(TestSingleThreadCalculation, addSubMatrix) {
 }
 
 TEST_F(TestSingleThreadCalculation, sustractWholeMatrix) {
-    output = Matrix<>(Shape{3, 3}, 0);
+    output = Matrix<double>(Shape{3, 3}, 0);
     subtractSingleThread(a, b, output, 0, a.size());
-    Matrix<> result({{-1, 0, 0}, {1, 0, 1}, {2, 2, 1}});
+    Matrix<double> result({{-1, 0, 0}, {1, 0, 1}, {2, 2, 1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 
     subtractSingleThread(b, a, output, 0, b.size());
-    result = Matrix<>({{1, 0, 0}, {-1, 0, -1}, {-2, -2, -1}});
+    result = Matrix<double>({{1, 0, 0}, {-1, 0, -1}, {-2, -2, -1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, sustractSubMatrix) {
-    output = Matrix<>(Shape{3, 3}, -1);
+    output = Matrix<double>(Shape{3, 3}, -1);
     subtractSingleThread(a, b, output, 3, 6);
-    Matrix<> result({{-1, -1, -1}, {1, 0, 1}, {2, 2, 1}});
+    Matrix<double> result({{-1, -1, -1}, {1, 0, 1}, {2, 2, 1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 
     subtractSingleThread(b, a, output, 3, 6);
-    result = Matrix<>({{-1, -1, -1}, {-1, 0, -1}, {-2, -2, -1}});
+    result = Matrix<double>({{-1, -1, -1}, {-1, 0, -1}, {-2, -2, -1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, multiplyWholeMatrix) {
-    output = Matrix<>(Shape{3, 3}, 0);
+    output = Matrix<double>(Shape{3, 3}, 0);
     multiplySingleThread(a, one, output, 0, a.size());
-    Matrix<> result({{0, 0, 0}, {3, 3, 3}, {6, 6, 6}});
+    Matrix<double> result({{0, 0, 0}, {3, 3, 3}, {6, 6, 6}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 
     multiplySingleThread(one, a, output, 0, one.size());
-    result = Matrix<>(Shape{3, 3}, 3);
+    result = Matrix<double>(Shape{3, 3}, 3);
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, multiplySubMatrix) {
-    output = Matrix<>(Shape{3, 3}, -1);
+    output = Matrix<double>(Shape{3, 3}, -1);
     multiplySingleThread(a, one, output, 4, 5);
-    Matrix<> result({{-1, -1, -1}, {-1, 3, 3}, {6, 6, 6}});
+    Matrix<double> result({{-1, -1, -1}, {-1, 3, 3}, {6, 6, 6}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 
     multiplySingleThread(one, a, output, 4, 5);
-    result = Matrix<>({{-1, -1, -1}, {-1, 3, 3}, {3, 3, 3}});
+    result = Matrix<double>({{-1, -1, -1}, {-1, 3, 3}, {3, 3, 3}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, transposeWholeMatrix) {
-    output = Matrix<>(Shape{3, 3}, 0);
+    output = Matrix<double>(Shape{3, 3}, 0);
     transposeSingleThread(c, output, 0, c.size());
-    Matrix<> result({{1, 4, 7}, {2, 5, 8}, {3, 6, 9}});
+    Matrix<double> result({{1, 4, 7}, {2, 5, 8}, {3, 6, 9}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
 TEST_F(TestSingleThreadCalculation, transposeSubMatrix) {
-    output = Matrix<>(Shape{3, 3}, -1);
+    output = Matrix<double>(Shape{3, 3}, -1);
     transposeSingleThread(c, output, 4, 5);
-    Matrix<> result({{-1, -1, -1}, {-1, 5, 8}, {3, 6, 9}});
+    Matrix<double> result({{-1, -1, -1}, {-1, 5, 8}, {3, 6, 9}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 


### PR DESCRIPTION
In order to make the matrix class similar with `std`'s containers, we add some member types in matrix class. And we add iterators for matrix class.

See #110.