### PR TITLE
Update some methods of multi thread

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -1,4 +1,5 @@
-# This starter workflow is for a CMake project running on multiple platforms. There is a different starter workflow if you just want a single platform.
+# This starter workflow is for a CMake project running on multiple platforms.
+# There is a different starter workflow if you just want a single platform.
 # See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-single-platform.yml
 name: CMake on multiple platforms
 
@@ -11,21 +12,22 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
-      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
+      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations.
+      # Consider changing this to true when your workflow is stable.
       fail-fast: false
 
       # Set up a matrix to run the following 3 configurations:
-      # 1. <Windows, Release, latest MSVC compiler toolchain on the default runner image, default generator>
+      # 1. <Windows, Release, MSVC compiler toolchain on the default runner image, default generator>
       # 2. <Linux, Release, latest GCC compiler toolchain on the default runner image, default generator>
       # 3. <Linux, Release, latest Clang compiler toolchain on the default runner image, default generator>
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2019]
         build_type: [Release]
         c_compiler: [gcc, clang, cl]
         include:
-          - os: windows-latest
+          - os: windows-2019
             c_compiler: cl
             cpp_compiler: cl
           - os: ubuntu-latest
@@ -35,9 +37,9 @@ jobs:
             c_compiler: clang
             cpp_compiler: clang++
         exclude:
-          - os: windows-latest
+          - os: windows-2019
             c_compiler: gcc
-          - os: windows-latest
+          - os: windows-2019
             c_compiler: clang
           - os: ubuntu-latest
             c_compiler: cl
@@ -46,7 +48,8 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set reusable strings
-      # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
+      # Turn repeated input strings (such as the build output directory) into step outputs.
+      # These step outputs can be used throughout the workflow file.
       id: strings
       shell: bash
       run: |

--- a/src/include/mca/matrix.h
+++ b/src/include/mca/matrix.h
@@ -158,11 +158,7 @@ public:
     void fill(const_reference value, const size_type &pos = 0);
 
     /* Calculate number ^ (*this), and return the result
-     * The function whose parameters do not include output will change (*this)
-     * NOTE: (*this) must have the same shape with output
-     *       If O and value_type are not same, all the elements will first be cast to
-     *       std::common_type_t<O, value_type>, after calculation they will be cast into O
-     *       by using static_cast
+     * This function do not change the (*this)
      * for example: a = [[1, 2, 3],
      *                   [2, 3, 4]]
      *              a.numberPow(2)
@@ -172,49 +168,41 @@ public:
      *                       [2^2, 2^3, 2^4]] */
     template <class Number, class = std::enable_if_t<!is_matrix_v<Number>>>
     inline Matrix numberPow(const Number &number) {
-        Matrix<value_type> output((*this).shape());
+        Matrix<value_type> output(shape());
         mca::numberPow(number, *this, output);
         return output;
     }
 
     /* Calculate (*this) ^ number, and return the result
-     * The function whose parameters do not include output will change (*this)
-     * NOTE: (*this) must have the same shape with output
-     *       If O and value_type are not same, all the elements will first be cast to
-     *       std::common_type_t<O, value_type>, after calculation they will be cast into O
-     *       by using static_cast
+     * This function do not change the (*this)
      * for example: a = [[1, 2, 3],
      *                   [2, 3, 4]]
      *              a.powNumber(2)
      *              a = [[1, 2, 3],
      *                   [2, 3, 4]]
-     *              output: [[1^2, 2^2, 3^2],
+     *              return: [[1^2, 2^2, 3^2],
      *                       [2^2, 3^2, 4^2]] */
     template <class Number, class = std::enable_if_t<!is_matrix_v<Number>>>
     inline Matrix powNumber(const Number &number) {
-        Matrix<value_type> output((*this).shape());
+        Matrix<value_type> output(shape());
         mca::powNumber(*this, number, output);
         return output;
     }
 
-    /* Calculate (*this) ^ exponent, and store the result in output
+    /* Calculate (*this) ^ exponent, and return the result
+     * This function do not change the (*this)
      * This is different with powNumber or numberPow
      * This will calculate the matrix exponentiation
      * This is only valid when (*this) is a square matrix
-     * The function whose parameters do not include output will change (*this)
-     * NOTE: (*this) must be a square matrix
-     *       (*this) must have the same shape with output
-     *       If O and value_type are not same, all the elements will first be cast to
-     *       std::common_type<O, value_type>, after calculation they will be cast into O
-     *       by using static_cast
      * for example: a = [[1, 2],
      *                   [2, 3]]
      *              a.pow(2)
-     *              output = [[5, 8],
+     *              return:  [[5, 8],
      *                        [8, 13]] */
     //     void pow(const size_type &exponent, Matrix<O> &output) const;
     inline Matrix pow(const size_type &exponent) const {
-        Matrix<value_type> output((*this).shape());
+        assert(isSquare());
+        Matrix<value_type> output(shape());
         mca::pow(*this, exponent, output);
         return output;
     }

--- a/src/include/mca/matrix.h
+++ b/src/include/mca/matrix.h
@@ -157,7 +157,7 @@ public:
      * pos should be less than or equal to size() */
     void fill(const_reference value, const size_type &pos = 0);
 
-    /* Calculate number ^ (*this), and store the result in output
+    /* Calculate number ^ (*this), and return the result
      * The function whose parameters do not include output will change (*this)
      * NOTE: (*this) must have the same shape with output
      *       If O and value_type are not same, all the elements will first be cast to
@@ -165,20 +165,19 @@ public:
      *       by using static_cast
      * for example: a = [[1, 2, 3],
      *                   [2, 3, 4]]
-     *              a.numberPow(2, output)
-     *              output: [[2^1, 2^2, 2^3],
-     *                       [2^2, 2^3, 2^4]]
      *              a.numberPow(2)
-     *              a: [[2^1, 2^2, 2^3],
-     *                  [2^2, 2^3, 2^4]] */
-    template <class Number, class O, class = std::enable_if_t<!is_matrix_v<Number>>>
-    void numberPow(const Number &number, Matrix<O> &output) const;
+     *              a: [[1, 2, 3],
+     *                  [2, 3, 4]]
+     *              return: [[2^1, 2^2, 2^3],
+     *                       [2^2, 2^3, 2^4]] */
     template <class Number, class = std::enable_if_t<!is_matrix_v<Number>>>
-    inline void numberPow(const Number &number) {
-        numberPow(number, *this);
+    inline Matrix numberPow(const Number &number) {
+        Matrix<value_type> output((*this).shape());
+        mca::numberPow(number, *this, output);
+        return output;
     }
 
-    /* Calculate (*this) ^ number, and store the result in output
+    /* Calculate (*this) ^ number, and return the result
      * The function whose parameters do not include output will change (*this)
      * NOTE: (*this) must have the same shape with output
      *       If O and value_type are not same, all the elements will first be cast to
@@ -186,17 +185,16 @@ public:
      *       by using static_cast
      * for example: a = [[1, 2, 3],
      *                   [2, 3, 4]]
-     *              a.powNumber(2, output)
+     *              a.powNumber(2)
+     *              a = [[1, 2, 3],
+     *                   [2, 3, 4]]
      *              output: [[1^2, 2^2, 3^2],
-     *                       [2^2, 3^2, 4^2]]
-     *              a.numberPow(2)
-     *              a: [[1^2, 2^2, 3^2],
-     *                  [2^2, 3^2, 4^2]] */
-    template <class Number, class O, class = std::enable_if_t<!is_matrix_v<Number>>>
-    void powNumber(const Number &number, Matrix<O> &output) const;
+     *                       [2^2, 3^2, 4^2]] */
     template <class Number, class = std::enable_if_t<!is_matrix_v<Number>>>
-    inline void powNumber(const Number &number) {
-        powNumber(number, *this);
+    inline Matrix powNumber(const Number &number) {
+        Matrix<value_type> output((*this).shape());
+        mca::powNumber(*this, number, output);
+        return output;
     }
 
     /* Calculate (*this) ^ exponent, and store the result in output
@@ -211,12 +209,15 @@ public:
      *       by using static_cast
      * for example: a = [[1, 2],
      *                   [2, 3]]
-     *              a.pow(2, output)
+     *              a.pow(2)
      *              output = [[5, 8],
      *                        [8, 13]] */
-    template <class O>
-    void pow(const size_type &exponent, Matrix<O> &output) const;
-    inline void pow(const size_type &exponent) { pow(exponent, *this); }
+    //     void pow(const size_type &exponent, Matrix<O> &output) const;
+    inline Matrix pow(const size_type &exponent) const {
+        Matrix<value_type> output((*this).shape());
+        mca::pow(*this, exponent, output);
+        return output;
+    }
 
     /* Return the transposed matrix of (*this)
      * for example: a = [[1, 2, 3],
@@ -492,85 +493,6 @@ void Matrix<T>::fill(const_reference value, const size_type &pos) {
 }
 
 template <class T>
-template <class Number, class O, class>
-void Matrix<T>::numberPow(const Number &number, Matrix<O> &output) const {
-    // single mode
-    if (threadNum() == 0 || limit() >= size()) {
-        numberPowSingleThread(number, *this, output, 0, size());
-        return;
-    }
-    // threadCalculation and taskNum
-    auto res = threadCalculationTaskNum(size());
-
-    // the return value of every task, use this to make sure every task is finished
-    std::vector<std::future<void>> returnValue(res.taskNum - 1);
-    // assign task for every sub-thread
-    for (size_type i = 0; i < res.taskNum - 1; i++) {
-        returnValue[i] = threadPool().addTask(
-            [this, start = i * res.calculation, len = res.calculation, &output, &number]() {
-                numberPowSingleThread(number, *this, output, start, len);
-            });
-    }
-    // let main thread calculate took
-    numberPowSingleThread(number,
-                          *this,
-                          output,
-                          (res.taskNum - 1) * res.calculation,
-                          (size() - (res.taskNum - 1) * res.calculation));
-
-    // make sure all the sub threads are finished
-    for (auto &item : returnValue) { item.get(); }
-}
-
-template <class T>
-template <class Number, class O, class>
-void Matrix<T>::powNumber(const Number &number, Matrix<O> &output) const {
-    // single mode
-    if (threadNum() == 0 || limit() >= size()) {
-        powNumberSingleThread(*this, number, output, 0, size());
-        return;
-    }
-    // threadCalculation and taskNum
-    auto res = threadCalculationTaskNum(size());
-
-    // the return value of every task, use this to make sure every task is finished
-    std::vector<std::future<void>> returnValue(res.taskNum - 1);
-    // assign task for every sub-thread
-    for (size_type i = 0; i < res.taskNum - 1; i++) {
-        returnValue[i] = threadPool().addTask(
-            [this, start = i * res.calculation, len = res.calculation, &output, &number]() {
-                powNumberSingleThread(*this, number, output, start, len);
-            });
-    }
-    // let main thread calculate took
-    powNumberSingleThread(*this,
-                          number,
-                          output,
-                          (res.taskNum - 1) * res.calculation,
-                          (size() - (res.taskNum - 1) * res.calculation));
-
-    // make sure all the sub threads are finished
-    for (auto &item : returnValue) { item.get(); }
-}
-
-template <class T>
-template <class O>
-void Matrix<T>::pow(const size_type &exponent, Matrix<O> &output) const {
-    assert(isSquare());
-    assert(shape() == output.shape());
-    size_type b = exponent;
-    Matrix<value_type> a(*this);
-    // make output an identity matrix
-    output = Matrix<O>(output.shape(), IdentityMatrix());
-    while (b > 0) {
-        if (b & 1) { output *= a; }
-        if ((b >> 1) == 0) { break; }
-        a *= a;
-        b >>= 1;
-    }
-}
-
-template <class T>
 bool Matrix<T>::symmetric() const {
     if (!isSquare()) { return false; }
     // single mode
@@ -599,6 +521,7 @@ bool Matrix<T>::symmetric() const {
     for (auto &item : returnValue) { result &= item.get(); }
     return result;
 }
+
 template <class T>
 bool Matrix<T>::antisymmetric() const {
     if (!isSquare()) { return false; }

--- a/src/include/mca/mca.h
+++ b/src/include/mca/mca.h
@@ -306,7 +306,7 @@ template <class T>
 void transpose(Matrix<T> &a);
 
 /* Store the transposed matrix of a in output using multi-thread
- * NOTE: output must have the same shape with the current matrix after transposition
+ * NOTE: output must have the same shape with the matrix after transposition
  *       If O and T are not same, all the elements will first be cast to
  *       std::common_type<O, T>, after calculation they will be cast into O
  *       by using static_cast
@@ -321,33 +321,30 @@ void transpose(Matrix<T> &a);
 template <class T, class O>
 void transpose(const Matrix<T> &a, Matrix<O> &output);
 
-/* Calculate the exponentiation of a square matrix, and store the result in matrix a
+/* Calculate the exponentiation of a square matrix in place, which means a will be changed
  * This is different from powNumber or numberPow
  * This will calculate the exponentiation of matrix
- * This is only valid when the matrix a is a square matrix
  * NOTE: Matrix a must be a square matrix
- *       If O and value_type are not same, all the elements will first be cast to
- *       std::common_type<O, value_type>, after calculation they will be cast into O
- *       by using static_cast
- * for example:  a = [[1, 2],
- *                    [2, 3]]
- *              pow(2, a)
+ * for example: a = [[1, 2],
+ *                   [2, 3]]
+ *              pow(a, 1)
  *              a:  [[5, 8],
  *                   [8, 13]] */
 template <class T>
 void pow(Matrix<T> &a, const size_type &exponent);
 
 /* Calculate the exponentiation of a square matrix, and store the result in output
- * Most of the things to note about this function are the same as the previous one
+ * This is different from powNumber or numberPow
+ * This will calculate the exponentiation of matrix
  * NOTE: Matrix a must be a square matrix
- *       output must have the same shape as the current matrix a
+ *       output must have the same shape as the matrix a
  *       If O and T are not same, all the elements will first be cast to
  *       std::common_type<O, T>, after calculation they will be cast into O
  *       by using static_cast
  * for example: a = [[1, 2, 3],
  *                   [2, 3, 4],
  *                   [7, 8, 9]]
- *              pow(2, a, output)
+ *              pow(a, 2, output)
  *              a: [[1, 2, 3],
  *                  [2, 3, 4]
  *                  [7, 8, 9]]
@@ -359,7 +356,7 @@ void pow(const Matrix<T> &a, const size_type &exponent, Matrix<O> &output);
 
 /* Calculate number ^ elements of the matrix a, and store the result in output
  * The function whose parameters do not include output will change the matrix a
- * NOTE: Matrix a must have the same shape as output
+ * NOTE: output must have the same shape as matrix a
  *       If O and value_type are not same, all the elements will first be cast to
  *       std::common_type_t<O, value_type>, after calculation they will be cast into O
  *       by using static_cast
@@ -376,14 +373,14 @@ void numberPow(const Number &number, Matrix<T> &a, Matrix<O> &output);
 template <class Number, class T, class = std::enable_if_t<!is_matrix_v<Number>>>
 void numberPow(const Number &number, Matrix<T> &a);
 
-/* Calculate the elements of the matrix a ^ number, and store the result in output
+/* Calculate the elements of the matrix a to the number-th power, and store the result in output
  * The function whose parameters do not include output will change the matrix a
  * NOTE: Matrix a must have the same shape as output
  *       If O and value_type are not same, all the elements will first be cast to
  *       std::common_type_t<O, value_type>, after calculation they will be cast into O
  *       by using static_cast
  * for example:  a = [[1, 2, 3],
- *                   [2, 3, 4]]
+ *                    [2, 3, 4]]
  *              powNumber(a, 2, output)
  *               a:  [[1, 2, 3],
  *                    [2, 3, 4]]

--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -10,7 +10,7 @@ void ThreadPool::resize(size_type newSize) {
     assert(taskQueue.size() == 0);
     taskQueue.reserve(newSize);
     while (taskQueue.size() < newSize) {
-        taskQueue.emplace_back(std::queue<std::function<void()>>());
+        taskQueue.emplace_back();
     }
     assert(size() == 0);
     for (size_type i = 0; i < newSize; i++) {

--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -9,9 +9,7 @@ void ThreadPool::resize(size_type newSize) {
     stopped.store(false, std::memory_order_relaxed);
     assert(taskQueue.size() == 0);
     taskQueue.reserve(newSize);
-    while (taskQueue.size() < newSize) {
-        taskQueue.emplace_back();
-    }
+    while (taskQueue.size() < newSize) { taskQueue.emplace_back(); }
     assert(size() == 0);
     for (size_type i = 0; i < newSize; i++) {
         threadQueue.emplace([this, id = size()]() {

--- a/test/src/multi_thread_matrix_calculation_test.cpp
+++ b/test/src/multi_thread_matrix_calculation_test.cpp
@@ -22,6 +22,7 @@ protected:
     Shape mul2Shape{121, 100};
     Shape rectangleShape1{1000, 1210};
     Shape rectangleShape2{1210, 1000};
+    Shape powShape{100, 100};
     std::default_random_engine generator;
     Matrix<double> singleOutput, multiOutput, a, b, c, mulA, mulB;
 
@@ -676,6 +677,182 @@ TEST_F(TestMultiThreadCalculation, transposeMatrixToOutput) {
     startTime = high_resolution_clock::now();
     // get multi-thread transpose in multiOutput
     transpose(a, multiOutput);
+    endTime       = high_resolution_clock::now();
+    executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record multi-thread time in gtest
+    testing::Test::RecordProperty("MultiTime", executionTime);
+
+    // make sure they are equal
+    ASSERT_EQ(singleOutput, multiOutput);
+}
+
+TEST_F(TestMultiThreadCalculation, pow) {
+    auto value = generator() % MAX_VALUE, exponent = generator() % MAX_VALUE;
+
+    singleOutput = multiOutput = Matrix<double>(powShape, value);
+
+    auto startTime = high_resolution_clock::now();
+    pow(singleOutput, exponent);
+    auto endTime       = high_resolution_clock::now();
+    auto executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record time in gtest
+    testing::Test::RecordProperty("SingleTime", executionTime);
+
+    init(THREAD_NUM);
+    // the expected time in multi thread
+    testing::Test::RecordProperty("BaseTime", executionTime / (threadNum() + 1));
+
+    // get the multi-thread mode time
+    startTime = high_resolution_clock::now();
+    // get multi-thread transpose in multiOutput
+    pow(multiOutput, exponent);
+    endTime       = high_resolution_clock::now();
+    executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record multi-thread time in gtest
+    testing::Test::RecordProperty("MultiTime", executionTime);
+
+    // make sure they are equal
+    ASSERT_EQ(singleOutput, multiOutput);
+}
+
+TEST_F(TestMultiThreadCalculation, powToOutput) {
+    auto value = generator() % MAX_VALUE, exponent = generator() % MAX_VALUE;
+
+    singleOutput = multiOutput = Matrix<double>(powShape);
+
+    a = Matrix<double>(powShape, value);
+
+    auto startTime = high_resolution_clock::now();
+    pow(a, exponent, singleOutput);
+    auto endTime       = high_resolution_clock::now();
+    auto executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record time in gtest
+    testing::Test::RecordProperty("SingleTime", executionTime);
+
+    init(THREAD_NUM);
+    // the expected time in multi thread
+    testing::Test::RecordProperty("BaseTime", executionTime / (threadNum() + 1));
+
+    // get the multi-thread mode time
+    startTime = high_resolution_clock::now();
+    // get multi-thread transpose in multiOutput
+    pow(a, exponent, multiOutput);
+    endTime       = high_resolution_clock::now();
+    executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record multi-thread time in gtest
+    testing::Test::RecordProperty("MultiTime", executionTime);
+
+    // make sure they are equal
+    ASSERT_EQ(singleOutput, multiOutput);
+}
+
+TEST_F(TestMultiThreadCalculation, numberPowMatrix) {
+    auto value = generator() % MAX_VALUE, number = generator() % MAX_VALUE;
+
+    singleOutput = multiOutput = Matrix<double>(powShape, value);
+
+    auto startTime = high_resolution_clock::now();
+    numberPow(number, singleOutput);
+    auto endTime       = high_resolution_clock::now();
+    auto executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record time in gtest
+    testing::Test::RecordProperty("SingleTime", executionTime);
+
+    init(THREAD_NUM);
+    // the expected time in multi thread
+    testing::Test::RecordProperty("BaseTime", executionTime / (threadNum() + 1));
+
+    // get the multi-thread mode time
+    startTime = high_resolution_clock::now();
+    // get multi-thread transpose in multiOutput
+    numberPow(number, multiOutput);
+    endTime       = high_resolution_clock::now();
+    executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record multi-thread time in gtest
+    testing::Test::RecordProperty("MultiTime", executionTime);
+
+    // make sure they are equal
+    ASSERT_EQ(singleOutput, multiOutput);
+}
+
+TEST_F(TestMultiThreadCalculation, numberPowMatrixToOutput) {
+    auto value = generator() % MAX_VALUE, number = generator() % MAX_VALUE;
+
+    a = singleOutput = multiOutput = Matrix<double>(powShape, value);
+
+    auto startTime = high_resolution_clock::now();
+    numberPow(number, a, singleOutput);
+    auto endTime       = high_resolution_clock::now();
+    auto executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record time in gtest
+    testing::Test::RecordProperty("SingleTime", executionTime);
+
+    init(THREAD_NUM);
+    // the expected time in multi thread
+    testing::Test::RecordProperty("BaseTime", executionTime / (threadNum() + 1));
+
+    // get the multi-thread mode time
+    startTime = high_resolution_clock::now();
+    // get multi-thread transpose in multiOutput
+    numberPow(number, a, multiOutput);
+    endTime       = high_resolution_clock::now();
+    executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record multi-thread time in gtest
+    testing::Test::RecordProperty("MultiTime", executionTime);
+
+    // make sure they are equal
+    ASSERT_EQ(singleOutput, multiOutput);
+}
+
+TEST_F(TestMultiThreadCalculation, powNumberMatrix) {
+    auto value = generator() % MAX_VALUE, number = generator() % MAX_VALUE;
+
+    singleOutput = multiOutput = Matrix<double>(powShape, value);
+
+    auto startTime = high_resolution_clock::now();
+    powNumber(singleOutput, number);
+    auto endTime       = high_resolution_clock::now();
+    auto executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record time in gtest
+    testing::Test::RecordProperty("SingleTime", executionTime);
+
+    init(THREAD_NUM);
+    // the expected time in multi thread
+    testing::Test::RecordProperty("BaseTime", executionTime / (threadNum() + 1));
+
+    // get the multi-thread mode time
+    startTime = high_resolution_clock::now();
+    // get multi-thread transpose in multiOutput
+    powNumber(multiOutput, number);
+    endTime       = high_resolution_clock::now();
+    executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record multi-thread time in gtest
+    testing::Test::RecordProperty("MultiTime", executionTime);
+
+    // make sure they are equal
+    ASSERT_EQ(singleOutput, multiOutput);
+}
+
+TEST_F(TestMultiThreadCalculation, powNumberMatrixToOutput) {
+    auto value = generator() % MAX_VALUE, number = generator() % MAX_VALUE;
+
+    a = singleOutput = multiOutput = Matrix<double>(powShape, value);
+
+    auto startTime = high_resolution_clock::now();
+    powNumber(a, number, singleOutput);
+    auto endTime       = high_resolution_clock::now();
+    auto executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+    // record time in gtest
+    testing::Test::RecordProperty("SingleTime", executionTime);
+
+    init(THREAD_NUM);
+    // the expected time in multi thread
+    testing::Test::RecordProperty("BaseTime", executionTime / (threadNum() + 1));
+
+    // get the multi-thread mode time
+    startTime = high_resolution_clock::now();
+    // get multi-thread transpose in multiOutput
+    powNumber(a, number, multiOutput);
     endTime       = high_resolution_clock::now();
     executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
     // record multi-thread time in gtest

--- a/test/src/multi_thread_matrix_test.cpp
+++ b/test/src/multi_thread_matrix_test.cpp
@@ -215,14 +215,13 @@ TEST_F(TestMatrixMultiThread, assignments) {
 }
 
 TEST_F(TestMatrixMultiThread, powNumber) {
-    auto value = generator() % MAX_VALUE;
-
+    auto value         = generator() % MAX_VALUE;
     const auto &number = exponent;
 
-    singleOutput = multiOutput = Matrix<double>(squareShape, value);
+    a = singleOutput = multiOutput = Matrix<double>(squareShape, value);
 
-    auto startTime = high_resolution_clock::now();
-    singleOutput.powNumber(number);
+    auto startTime     = high_resolution_clock::now();
+    singleOutput       = a.powNumber(number);
     auto endTime       = high_resolution_clock::now();
     auto executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
     // record time in gtest
@@ -235,40 +234,7 @@ TEST_F(TestMatrixMultiThread, powNumber) {
     // get the multi-thread mode time
     startTime = high_resolution_clock::now();
     // get multi-thread pownumber in multiThread
-    multiOutput.powNumber(number);
-    endTime       = high_resolution_clock::now();
-    executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
-    // record multi-thread time in gtest
-    testing::Test::RecordProperty("MultiTime", executionTime);
-
-    // make sure they are equal
-    ASSERT_EQ(singleOutput, multiOutput);
-}
-
-TEST_F(TestMatrixMultiThread, powNumberToOutput) {
-    auto value = generator() % MAX_VALUE;
-
-    singleOutput = multiOutput = Matrix<double>(squareShape);
-
-    const auto &number = exponent;
-
-    a = Matrix<double>(squareShape, value);
-
-    auto startTime = high_resolution_clock::now();
-    a.powNumber(number, singleOutput);
-    auto endTime       = high_resolution_clock::now();
-    auto executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
-    // record time in gtest
-    testing::Test::RecordProperty("SingleTime", executionTime);
-
-    init(THREAD_NUM);
-    // the expected time in multi thread
-    testing::Test::RecordProperty("BaseTime", executionTime / (threadNum() + 1));
-
-    // get the multi-thread mode time
-    startTime = high_resolution_clock::now();
-    // get multi-thread pownumber in multiOutput
-    a.powNumber(number, multiOutput);
+    multiOutput   = a.powNumber(number);
     endTime       = high_resolution_clock::now();
     executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
     // record multi-thread time in gtest
@@ -279,15 +245,14 @@ TEST_F(TestMatrixMultiThread, powNumberToOutput) {
 }
 
 TEST_F(TestMatrixMultiThread, numberPow) {
-    auto value = generator() % MAX_VALUE;
-
+    auto value         = generator() % MAX_VALUE;
     const auto &number = exponent;
 
-    singleOutput = multiOutput = Matrix<double>(squareShape, value);
+    a = singleOutput = multiOutput = Matrix<double>(squareShape, value);
 
     // first use numberPowSingleThread to get the single mode time
-    auto startTime = high_resolution_clock::now();
-    singleOutput.numberPow(number);
+    auto startTime     = high_resolution_clock::now();
+    singleOutput       = a.numberPow(number);
     auto endTime       = high_resolution_clock::now();
     auto executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
     // record time in gtest
@@ -300,40 +265,7 @@ TEST_F(TestMatrixMultiThread, numberPow) {
     // get the multi-thread mode time
     startTime = high_resolution_clock::now();
     // get multi-thread pownumber in multiThread
-    multiOutput.numberPow(number);
-    endTime       = high_resolution_clock::now();
-    executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
-    // record multi-thread time in gtest
-    testing::Test::RecordProperty("MultiTime", executionTime);
-
-    // make sure they are equal
-    ASSERT_EQ(singleOutput, multiOutput);
-}
-
-TEST_F(TestMatrixMultiThread, numberPowToOutput) {
-    auto value = generator() % MAX_VALUE;
-
-    singleOutput = multiOutput = Matrix<double>(squareShape);
-
-    const auto &number = exponent;
-
-    a = Matrix<double>(squareShape, value);
-    // first use numberPowSingleThread to get the single mode time
-    auto startTime = high_resolution_clock::now();
-    a.numberPow(number, singleOutput);
-    auto endTime       = high_resolution_clock::now();
-    auto executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
-    // record time in gtest
-    testing::Test::RecordProperty("SingleTime", executionTime);
-
-    init(THREAD_NUM);
-    // the expected time in multi thread
-    testing::Test::RecordProperty("BaseTime", executionTime / (threadNum() + 1));
-
-    // get the multi-thread mode time
-    startTime = high_resolution_clock::now();
-    // get multi-thread pownumber in multiOutput
-    a.numberPow(number, multiOutput);
+    multiOutput   = a.numberPow(number);
     endTime       = high_resolution_clock::now();
     executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
     // record multi-thread time in gtest
@@ -346,10 +278,10 @@ TEST_F(TestMatrixMultiThread, numberPowToOutput) {
 TEST_F(TestMatrixMultiThread, pow) {
     auto value = generator() % MAX_VALUE;
 
-    singleOutput = multiOutput = Matrix<double>(powShape, value);
+    a = singleOutput = multiOutput = Matrix<double>(powShape, value);
 
-    auto startTime = high_resolution_clock::now();
-    singleOutput.pow(exponent);
+    auto startTime     = high_resolution_clock::now();
+    singleOutput       = a.pow(exponent);
     auto endTime       = high_resolution_clock::now();
     auto executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
     // record time in gtest
@@ -362,38 +294,7 @@ TEST_F(TestMatrixMultiThread, pow) {
     // get the multi-thread mode time
     startTime = high_resolution_clock::now();
     // get multi-thread pownumber in multiThread
-    multiOutput.pow(exponent);
-    endTime       = high_resolution_clock::now();
-    executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
-    // record multi-thread time in gtest
-    testing::Test::RecordProperty("MultiTime", executionTime);
-
-    // make sure they are equal
-    ASSERT_EQ(singleOutput, multiOutput);
-}
-
-TEST_F(TestMatrixMultiThread, powToOutput) {
-    auto value = generator() % MAX_VALUE;
-
-    singleOutput = multiOutput = Matrix<double>(powShape);
-
-    a = Matrix<double>(powShape, value);
-
-    auto startTime = high_resolution_clock::now();
-    a.pow(exponent, singleOutput);
-    auto endTime       = high_resolution_clock::now();
-    auto executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
-    // record time in gtest
-    testing::Test::RecordProperty("SingleTime", executionTime);
-
-    init(THREAD_NUM);
-    // the expected time in multi thread
-    testing::Test::RecordProperty("BaseTime", executionTime / (threadNum() + 1));
-
-    // get the multi-thread mode time
-    startTime = high_resolution_clock::now();
-    // get multi-thread pownumber in multiOutput
-    a.pow(exponent, multiOutput);
+    multiOutput   = a.pow(exponent);
     endTime       = high_resolution_clock::now();
     executionTime = duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
     // record multi-thread time in gtest

--- a/test/src/single_thread_matrix_calculation_test.cpp
+++ b/test/src/single_thread_matrix_calculation_test.cpp
@@ -221,7 +221,7 @@ TEST_F(TestSingleThreadCalculation, addSubMatrix) {
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
-TEST_F(TestSingleThreadCalculation, sustractWholeMatrix) {
+TEST_F(TestSingleThreadCalculation, subtractWholeMatrix) {
     output = Matrix<double>(Shape{3, 3}, 0);
     subtractSingleThread(a, b, output, 0, a.size());
     Matrix<double> result({{-1, 0, 0}, {1, 0, 1}, {2, 2, 1}});
@@ -232,7 +232,7 @@ TEST_F(TestSingleThreadCalculation, sustractWholeMatrix) {
     ASSERT_TRUE(equalSingleThread(output, result, 0, output.size()));
 }
 
-TEST_F(TestSingleThreadCalculation, sustractSubMatrix) {
+TEST_F(TestSingleThreadCalculation, subtractSubMatrix) {
     output = Matrix<double>(Shape{3, 3}, -1);
     subtractSingleThread(a, b, output, 3, 6);
     Matrix<double> result({{-1, -1, -1}, {1, 0, 1}, {2, 2, 1}});


### PR DESCRIPTION
We updated the `pow`, `powNumber` and `numberPow` metheds. We updated these three methods to make them consistent with the `transpose method`.

You can see the specific details in #112.

Update msvc version in git action, solved https://github.com/Kaiser-Yang/matrix-calculation-accelerator/issues/118, and see https://github.com/Kaiser-Yang/matrix-calculation-accelerator/issues/118 for more details.