### PR TITLE
Fix a bug: clang-format on wrong branches

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.base.ref }}  # assign the branch should be checked
+    
     
     - name: Install clang-format
       run: |


### PR DESCRIPTION
The clang-format will run on the compare branch rather than the base branch. Fix this by assign `ref`.