### PR TITLE
Finish documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@
 
 # compile commands
 compile_commands.json
+
+# root directory signature
+.root

--- a/doc/en/user/buildAndInstall.md
+++ b/doc/en/user/buildAndInstall.md
@@ -1,8 +1,19 @@
-A simply process can be depicted below:
+# Get started
+A simple process can be depicted below:
+
 1. First, you need clone or download the repository. And enter the root directory of the repository. 
 2. Use `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` to configure `cmake`.
 3. Enter the directory after argument `-B`, in this example it is `build`.
-4. Use `cmake --build . -j8` to compile the project. The `-j8` means compiling with `8` threads, and this has nothing to do with the number of threads when calculating, you can change the number if you like.
-5. Use `cmake --install . --prefix /usr` to install the library to `/usr`, you can change the argument after `--prefix` to specify where you want to install the library.
+4. Use `cmake --build . -j8` to compile the project. The `-j8` means compiling with `8` threads, and
+this has nothing to do with the number of threads when calculating, you can change the number if you
+like.
+5. Use `cmake --install . --prefix /usr` to install the library to `/usr`, you can change the
+argument after `--prefix` to specify where you want to install the library.
 
-Note that if you install the library to a directory which is not a shared library search directory, you may need update `LD_LIBRARY_PATH` to let the linker find the library when running it. Or you can build `mca` as a static library by adding `-Dmca_BUILD_SHARE_LIB=off` when configuring `cmake`.
+Note that if you install the library to a directory which is not a shared library search directory,
+you may need update `LD_LIBRARY_PATH` to let the linker find the library when running it. Or you can
+build `mca` as a static library by adding `-Dmca_BUILD_SHARE_LIB=off` when configuring `cmake`.
+
+[Next: `mca::Matrix`](matrix.md)
+
+[Back to the index](index.md)

--- a/doc/en/user/diag.md
+++ b/doc/en/user/diag.md
@@ -1,0 +1,45 @@
+# mca::_Diag
+```c++
+/* Defined in <mca/diag.h> */
+template <class Container> _Diag;
+```
+
+## Member types
+|           |   |
+| -         | - |
+| size_type | std::size_t |
+
+## Member functions
+### Constructors
+|                                         |   |
+| -                                       | - |
+| <nobr>`_Diag(const Container &)`</nobr> | Construct from a container. |
+| <nobr>`_Diag(Container &&)`</nobr>      | Construct from a container. |
+
+NOTE: You should not use `_Diag` to construct, you should use the
+[helper functions](#helper-functions) to construct.
+
+### Operators
+|                                                                                     |   |
+| -                                                                                   | - |
+| <nobr>`const typename Container::value_type &operator[](const size_type &i)`</nobr> | Return the i-th element of the container. |
+
+### Other
+|                                 |   |
+| -                               | - |
+| <nobr>`size_type size()`</nobr> | Return the size of the container. |
+
+## Helper functions
+|                                                                                           |   |
+| -                                                                                         | - |
+| <nobr>`_Diag<std::decay_t<Container>> Diag(Container &&container)`</nobr>                 | Return a `mca::_Diag` from a container. |
+| <nobr>`_Diag<std::initializer_list<T>> Diag(std::initializer_list<T> &&container)`</nobr> | Return a `mca::_Diag` from a `std::initializer_list`. |
+
+
+[Back to the `mca::Matrix`](matrix.md)
+
+[Back to the `mca::Shape`](shape.md)
+
+[Next: `mca::_IdentityMatrix`](identityMatrix.md)
+
+[Back to the index](index.md)

--- a/doc/en/user/identityMatrix.md
+++ b/doc/en/user/identityMatrix.md
@@ -1,0 +1,25 @@
+# mca::_IdentityMatrix
+```c++
+/* Defined in <mca/identity_matrix.h> */
+struct _IdentityMatrix;
+```
+
+NOTE: This class is a singleton class. And you should not construct from the `getInstance()`. You should
+use the [helper functions](#helper-functions) to get an instance.
+
+## Member functions
+|                                                            |   |
+| -                                                          | - |
+| <nobr>`static const _IdentityMatrix &getInstance()`</nobr> | Return a reference to the singleton instance. |
+## Helper functions
+|                                                        |   |
+| -                                                      | - |
+| <nobr>`const _IdentityMatrix &IdentityMatrix()`</nobr> | Return a reference to the singleton instance. |
+
+[Back to the `mca::Matrix`](matrix.md)
+
+[Back to the `mca::_Diag`](diag.md)
+
+[Next: `mca`](mca.md)
+
+[Back to the index](index.md)

--- a/doc/en/user/index.md
+++ b/doc/en/user/index.md
@@ -1,1 +1,11 @@
-[How to build and install `mca`?](buildAndInstall.md)
+[Get started](buildAndInstall.md)
+
+[`mca::Matrix`](matrix.md)
+
+[`mca::Shape`](shape.md)
+
+[`mca::_Diag`](diag.md)
+
+[`mca::_IdentityMatrix`](identityMatrix.md)
+
+[`mca`](mca.md)

--- a/doc/en/user/matrix.md
+++ b/doc/en/user/matrix.md
@@ -1,0 +1,101 @@
+# mca::Matrix
+```c++
+/* Defined in header file <mca/matrix.h> */
+template <class T> class Matrix;
+```
+## Member types
+|                                       |   |
+| -                                     | - |
+| <nobr>`value_type`</nobr>             | <nobr>`T`</nobr> |
+| <nobr>`size_type`</nobr>              | <nobr>`std::size_t`</nobr> |
+| <nobr>`difference_type`</nobr>        | <nobr>`std::ptrdiff_t`</nobr> |
+| <nobr>`reference`</nobr>              | <nobr>`T&`</nobr> |
+| <nobr>`const_reference`</nobr>        | <nobr>`const T&`</nobr> |
+| <nobr>`pointer`</nobr>                | <nobr>`T*`</nobr> |
+| <nobr>`const_pointer`</nobr>          | <nobr>`const T*`</nobr> |
+| <nobr>`iterator`</nobr>               | <nobr>`T*`</nobr> |
+| <nobr>`const_iterator`</nobr>         | <nobr>`const T*`</nobr> |
+| <nobr>`reverse_iterator`</nobr>       | <nobr>`std::reverse_iterator<iterator>`</nobr> |
+| <nobr>`const_reverse_iterator`</nobr> | <nobr>`std::reverse_iterator<const_iterator>`</nobr> |
+
+## Member functions
+### Constructors
+|                                                                                             |   |
+| -                                                                                           | - |
+| <nobr>`Matrix()`</nobr>                                                                     | Construct an empty matrix. |
+| <nobr>`Matrix(const Shape &shape, const _IdentityMatrix &)`</nobr>                          | Construct an identity matrix with the given shape. |
+| <nobr>`Matrix(const std::initializer_list<std::initializer_list<value_type>> &init)`</nobr> | Construct a matrix from a list of lists. |
+| <nobr>`Matrix(const std::vector<std::vector<value_type>> &init)`</nobr>                     | Construct a matrix from a vector of vectors. |
+| <nobr>`Matrix(const Shape &shape, const_pointer data, const size_type &len)`</nobr>         | Construct a matrix from a pointer. When `len` is less than `shape.size()`, the rest part will be filled with `value_type()` |
+| <nobr>`Matrix(const Shape &shape, const value_type (&array)[N])`</nobr>                     | Construct a matrix from an array. When `N` is less than `shape.size()`, the rest part will be filled with `value_type()` |
+| <nobr>`Matrix(const Shape &shape, std::array<value_type, N> &array)`</nobr>                 | Construct a matrix from a `std::array`. When `N` is less than `shape.size()`, the rest part will be filled with `value_type()` |
+| <nobr>`Matrix(const Shape &shape, const_reference defaultValue = value_type())`</nobr>      | Construct a matrix with the given shape and default value. |
+| <nobr>`Matrix(const _Diag<Container> &diag)`</nobr>                                         | Construct a diagonal matrix from a container. |
+| <nobr>`Matrix(const Matrix<T1> &other)`</nobr>                                              | Copy constructor. When `T1` is not the same as `T`, the elements will be converted to `T` by using `static_cast`. |
+| <nobr>`Matrix(Matrix &&other) noexcept`</nobr>                                              | Move constructor which only supports the matrices with same `value_type`. |
+
+[The examples of constructing a matrix.](../../../example/matrix_construction.cpp)
+
+### Operators
+|                                                                               |   |
+| -                                                                             | - |
+| <nobr>`Matrix &operator=(Matrix &&other) noexcept`</nobr>                     | Move assignment operator which only supports the matrices with same `value_type`. |
+| <nobr>`Matrix &operator=(const Matrix<T1> &other)`</nobr>                     | Copy assignment operator. When `T1` is not the same as `T`, the elements will be converted to `T` by using `static_cast`. |
+| <nobr>`[const_]reference operator[](const size_type &pos) [const]`</nobr>     | Get the element at pos, the elements are numbered sequentially from left to right and top to bottom. |
+
+This part has not been finished yet. Add some examples.
+
+### Iterators
+|                                                                   |   |
+| -                                                                 | - |
+| <nobr>`[const_]iterator begin() [const] noexcept`</nobr>          | Return an iterator to the beginning. |
+| <nobr>`[const_]iterator end() [const] noexcept`</nobr>            | Return an iterator to the end. |
+| <nobr>`const_iterator cbegin() const noexcept`</nobr>             | Return a const iterator to the beginning. |
+| <nobr>`const_iterator cend() const noexcept`</nobr>               | Return a const iterator to the end. |
+| <nobr>`[const_]reverse_iterator rbegin() [const] noexcept`</nobr> | Return a reverse iterator to the beginning. |
+| <nobr>`[const_]reverse_iterator rend() [const] noexcept`</nobr>   | Return a reverse iterator to the end. |
+| <nobr>`const_reverse_iterator crbegin() const noexcept`</nobr>    | Return a const reverse iterator to the beginning. |
+| <nobr>`const_reverse_iterator crend() const noexcept`</nobr>      | Return a const reverse iterator to the end. |
+
+This part has not been finished yet. Add some examples.
+
+### Other
+|                                                                                      |   |
+| -                                                                                    | - |
+| <nobr>`[const_]reference get(const size_type &i, const size_type &j) [const]`</nobr> | Get the element at (i, j). |
+| <nobr>`[const_]pointer data() [const] noexcept`</nobr>                               | Get the data pointer. |
+| <nobr>`size_type rows() const noexcept`</nobr>                                       | Get the number of rows. |
+| <nobr>`size_type cols() const noexcept`</nobr>                                       | Get the number of columns. |
+| <nobr>`size_type size() const noexcept`</nobr>                                       | Get the number of elements. |
+| <nobr>`Shape shape() const noexcept`</nobr>                                          | Get the shape of the matrix. |
+| <nobr>`void reshape(const Shape &shape) noexcept`</nobr>                             | Reshape the matrix. The size of the new shape must be same with the old one. |
+| <nobr>`void fill(const_reference value, const size_type &pos = 0)`</nobr>            | Fill the matrix with the given value from the given position. |
+| <nobr>`Matrix numberPow(const Number &number)`</nobr>                                | Return a matrix whose elements are the `number`s to the original element-th power. |
+| <nobr>`Matrix powNumber(const Number &number)`</nobr>                                | Return a matrix whose elements are the original elements to the `number`-th power. |
+| <nobr>`Matrix pow(const size_type &exponent) const`</nobr>                           | Return a result of the matrix raised to the power of `exponent`. The original matrix must be a square matrix. |
+| <nobr>`Matrix transpose() const`</nobr>                                              | Return the transpose of the matrix. |
+| <nobr>`bool square() const noexcept`</nobr>                                          | Check if the matrix is a square matrix. |
+| <nobr>`bool symmetric() const`</nobr>                                                | Check if the matrix is symmetric. |
+| <nobr>`bool antisymmetric() const`</nobr>                                            | Check if the matrix is antisymmetric. |
+| <nobr>`[const_]reference front() [const]`</nobr>                                     | Return the first element of the matrix, the size must be greater than `0` |
+| <nobr>`[const_]reference back() [const]`</nobr>                                      | Return the last element of the matrix, the size must be greater than `0` |
+| <nobr>`bool empty() const noexcept`</nobr>                                           | Check if the matrix is empty. |
+| <nobr>`void swap(Matrix &other) noexcept`</nobr>                                     | Swap the matrix with another matrix. Only the matrices with same `value_type` can be swapped. |
+
+This part has not been finished yet. Add some examples.
+
+## Non-member functions
+See [`mca`](mca.md) for more information.
+
+## Helper classes
+|                                             |   |
+| -                                           | - |
+| [`mca::Shape`](shape.md)                    | A helper class for matrices' shape |
+| [`mca::_Diag`](diag.md)                     | A helper class for diagonal matrices. |
+| [`mca::_IdentityMatrix`](identityMatrix.md) | A helper class for identity matrices. |
+
+[Back to the `Get started`](buildAndInstall.md)
+
+[Next: `mca::Shape`](shape.md)
+
+[Back to the index](index.md)

--- a/doc/en/user/mca.md
+++ b/doc/en/user/mca.md
@@ -1,0 +1,49 @@
+# Matrix calculation accelerator
+All the methods are defined in `mca.h`.
+
+|                                                                                            |   |
+| -                                                                                          | - |
+| <nobr>`bool operator==(const Matrix<T1> &a, const Matrix<T2> &b)`</nobr>                   | Return `true` if the two matrices are equal, `false` otherwise. |
+| <nobr>`bool operator!=(const Matrix<T1> &a, const Matrix<T2> &b)`</nobr>                   | Return `true` if the two matrices are not equal, `false` otherwise. |
+| <nobr>`bool operator<(const Matrix<T1> &a, const Matrix<T2> &b)`</nobr>                    | Return `true` if all elements of the first matrix is less than the second matrix, `false` otherwise. |
+| <nobr>`bool operator<=(const Matrix<T1> &a, const Matrix<T2> &b)`</nobr>                   | Return `true` if all elements of the first matrix is less than or equal to the second matrix, `false` otherwise. |
+| <nobr>`bool operator>(const Matrix<T1> &a, const Matrix<T2> &b)`</nobr>                    | Return `true` if all elements of the first matrix is greater than the second matrix, `false` otherwise. |
+| <nobr>`bool operator>=(const Matrix<T1> &a, const Matrix<T2> &b)`</nobr>                   | Return `true` if all elements of the first matrix is greater than or equal to the second matrix, `false` otherwise. |
+| <nobr>`Matrix operator+(const Matrix<T1> &a, const Matrix<T2> &b)`</nobr>                  | Return the sum of the two matrices. The `value_type` of the return value is `std::common_type_t<T1, T2>`. |
+| <nobr>`Matrix operator-(const Matrix<T1> &a, const Matrix<T2> &b)`</nobr>                  | Return the difference of the two matrices. The `value_type` of the return value is `std::common_type_t<T1, T2>`. |
+| <nobr>`Matrix operator*(const Matrix<T1> &a, const Matrix<T2> &b)`</nobr>                  | Return the product of the two matrices. The `value_type` of the return value is `std::common_type_t<T1, T2>`. |
+| <nobr>`Matrix operator+(const Matrix<T> &a, const Number &number)`</nobr>                  | Return `a + Matrix<Number>(a.shape(), number)`. The `value_type` of the return value is `std::common_type_t<T, Number>`. |
+| <nobr>`Matrix operator+(const Number &number, const Matrix<T> &a)`</nobr>                  | Return `a + Matrix<Number>(a.shape(), number)`. The `value_type` of the return value is `std::common_type_t<T, Number>`. |
+| <nobr>`Matrix operator-(const Matrix<T> &a, const Number &number)`</nobr>                  | Return `a - Matrix<Number>(a.shape(), number)`. The `value_type` of the return value is `std::common_type_t<T, Number>`. |
+| <nobr>`Matrix operator-(const Number &number, const Matrix<T> &a)`</nobr>                  | Return `Matrix<Number>(a.shape(), number) - a`. The `value_type` of the return value is `std::common_type_t<T, Number>`. |
+| <nobr>`Matrix operator*(const Matrix<T> &a, const Number &number)`</nobr>                  | Return a matrix whose elements are `a`'s multiplied by `number`. The `value_type` of the return value is `std::common_type_t<T, Number>`. |
+| <nobr>`Matrix operator*(const Number &number, const Matrix<T> &a)`</nobr>                  | Return a matrix whose elements are `a`'s multiplied by `number`. The `value_type` of the return value is `std::common_type_t<T, Number>`. |
+| <nobr>`Matrix operator/(const Matrix<T> &a, const Number &number)`</nobr>                  | Return a matrix whose elements are `a`'s divided by `number`. The `value_type` of the return value is `std::common_type_t<T, Number>`. |
+| <nobr>`Matrix operator/(const Number &number, const Matrix<T> &a)`</nobr>                  | Return a matrix whose elements are `number` divided by `a`'s elements. The `value_type` of the return value is `std::common_type_t<T, Number>`. |
+| <nobr>`void operator+=(Matrix<T1> &a, const Matrix<T2> &b)`</nobr>                         | Self matrix addition |
+| <nobr>`void operator-=(Matrix<T1> &a, const Matrix<T2> &b)`</nobr>                         | Self matrix subtraction |
+| <nobr>`void operator*=(Matrix<T1> &a, const Matrix<T2> &b)`</nobr>                         | Self matrix multiplication |
+| <nobr>`void operator+=(Matrix<T> &a, const Number &number)`</nobr>                         | Same with `a += Matrix<Number>(a.shape, number)`. |
+| <nobr>`void operator+=(const Number &number, Matrix<T> &a)`</nobr>                         | Same with `a += Matrix<Number>(a.shape, number)`. |
+| <nobr>`void operator-=(Matrix<T> &a, const Number &number)`</nobr>                         | Same with `a -= Matrix<Number>(a.shape, number)`. |
+| <nobr>`void operator-=(const Number &number, Matrix<T> &a)`</nobr>                         | Same with `a = Matrix<Number>(a.shape, number) - a`. |
+| <nobr>`void operator*=(Matrix<T> &a, const Number &number)`</nobr>                         | Same with `a *= Matrix<Number>(a.shape, number)`. |
+| <nobr>`void operator*=(const Number &number, Matrix<T> &a)`</nobr>                         | Same with `a *= Matrix<Number>(a.shape, number)`. |
+| <nobr>`void operator/=(Matrix<T> &a, const Number &number)`</nobr>                         | Same with `a /= Matrix<Number>(a.shape, number)`. |
+| <nobr>`void operator/=(const Number &number, Matrix<T> &a)`</nobr>                         | Same with `a = Matrix<Number>(a.shape, number) / a`. |
+| <nobr>`void transpose(Matrix<T> &a)`</nobr>                                                | Tranpose a matrix. |
+| <nobr>`void transpose(const Matrix<T> &a, Matrix<O> &output)`</nobr>                       | Tranpose a matrix, but store the result into `output`. |
+| <nobr>`void pow(Matrix<T> &a, const size_type &exponent)`</nobr>                           | Raise a matrix to the power of `exponent`. |
+| <nobr>`void pow(const Matrix<T> &a, const size_type &exponent, Matrix<O> &output)`</nobr>  | Raise a matrix to the power of `exponent`, but store the result into `output`. |
+| <nobr>`void numberPow(const Number &number, Matrix<T> &a)`</nobr>                          | `a`'s elements will be the `number`'s to the original element-th power. |
+| <nobr>`void numberPow(const Number &number, Matrix<T> &a, Matrix<O> &output)`</nobr>       | `output`'s elements will be the `number`'s to the `a`'s element-th power. |
+| <nobr>`void powNumber(Matrix<T> &a, const Number &number)`</nobr>                          | `a`'s elements will be the original to the `number`-th power. |
+| <nobr>`void powNumber(const Matrix<T> &a, const Number &number, Matrix<O> &output)`</nobr> | `output`'s elements will be the `a`'s elements to the `nubmer`-th power. |
+
+This part has not been finished yet: add some examples.
+
+[Back to the `mca::Matrix`](matrix.md)
+
+[Back to the `mca::_IdentityMatrix`](identityMatrix.md)
+
+[Back to the index](index.md)

--- a/doc/en/user/shape.md
+++ b/doc/en/user/shape.md
@@ -1,0 +1,44 @@
+# mca::Shape
+```c++
+/* Defined in header file <mca/shape.h> */
+struct Shape;
+```
+
+## Member types
+|           |   |
+| -         | - |
+| size_type | std::size_t |
+
+## Member variables
+|                        |   |
+| -                      | - |
+| <nobr>`rows`</nobr>    | The number of rows. |
+| <nobr>`Columns`</nobr> | The number of columns. |
+
+## Member functions
+### Constructors
+|                                                                       |   |
+| -                                                                     | - |
+| <nobr>`Shape()`</nobr>                                                | Construct a (0, 0) shape. |
+| <nobr>`Shape(const size_type &rows, const size_type &columns)`</nobr> | Construct a (rows, columns) shape. |
+| <nobr>`Shape(const Shape &)`</nobr>                                   | Copy constructor. |
+| <nobr>`Shape(Shape &&)`</nobr>                                        | Move constructor. |
+
+### Operators
+|                                                |   |
+| -                                              | - |
+| <nobr>`Shape &operator=(const Shape &)`</nobr> | Copy assignment. |
+| <nobr>`void operator=(Shape &&)`</nobr>        | Move assignment. |
+| <nobr>`bool operator==(const Shape &)`</nobr>  | Return `true` if two shapes are same, otherwise `false`. |
+| <nobr>`bool operator!=(const Shape &)`</nobr>  | Return `true` if two shapes are not same, otherwise `false`. |
+
+### Other
+|                                 |   |
+| -                               | - |
+| <nobr>`size_type size()`</nobr> | Return the size of a shape. |
+
+[Back to the `mca::Matrix`](matrix.md)
+
+[Next: `mca::_Diag`](diag.md)
+
+[Back to the index](index.md)

--- a/example/matrix_construction.cpp
+++ b/example/matrix_construction.cpp
@@ -1,15 +1,16 @@
 #include <example_utility.h>  // for operator<<
+#include <mca/diag.h>
 #include <mca/identity_matrix.h>
 #include <mca/matrix.h>
-#include <mca/diag.h>
 
+#include <array>
 #include <iostream>
 #include <memory>
 #include <vector>
-#include <array>
 
 int main() {
-    using mca::Matrix, mca::Shape, mca::IdentityMatrix, std::cout, std::vector, std::unique_ptr, std::make_unique, std::array, mca::Diag;
+    using mca::Matrix, mca::Shape, mca::IdentityMatrix, std::cout, std::vector, std::unique_ptr,
+        std::make_unique, std::array, mca::Diag;
 
     Matrix<int> m1;
     cout << "Construct an empty matrix:\n";
@@ -35,11 +36,9 @@ int main() {
     cout << "Construct an matrix from a std::vector:\n";
     cout << m6 << "\n";
 
-    constexpr size_t len = 6;
+    constexpr size_t len   = 6;
     unique_ptr<int[]> data = make_unique<int[]>(len);
-    for (int i = 0; i < len; i++) {
-        data[i] = i + 1;
-    }
+    for (int i = 0; i < len; i++) { data[i] = i + 1; }
     Matrix<int> m7(Shape(3, 3), data.get(), len);
     cout << "Construct an matrix from a raw pointer (the last three elements will be 0):\n";
     cout << m7 << "\n";

--- a/example/matrix_construction.cpp
+++ b/example/matrix_construction.cpp
@@ -1,35 +1,81 @@
 #include <example_utility.h>  // for operator<<
 #include <mca/identity_matrix.h>
 #include <mca/matrix.h>
+#include <mca/diag.h>
 
 #include <iostream>
+#include <memory>
+#include <vector>
+#include <array>
 
 int main() {
-    using mca::Matrix, mca::Shape, mca::IdentityMatrix, std::cout;
+    using mca::Matrix, mca::Shape, mca::IdentityMatrix, std::cout, std::vector, std::unique_ptr, std::make_unique, std::array, mca::Diag;
 
     Matrix<int> m1;
     cout << "Construct an empty matrix:\n";
     cout << m1 << "\n";
 
-    Matrix<int> m2(Shape(3, 3));
-    cout << "Construct a matrix whose shape is (3, 3) and elements are all int():\n";
+    Matrix<int> m2(Shape(3, 3), IdentityMatrix());
+    cout << "Construct an identity matrix whose shape is (3, 3):\n";
     cout << m2 << "\n";
 
-    Matrix<int> m3(Shape(3, 3), -1);
-    cout << "Construct a matrix whose shape is (3, 3) and elements are all -1:\n";
+    Matrix<int> m3(Shape(3, 4), IdentityMatrix());
+    cout << "Construct an identity matrix whose shape is (3, 4):\n";
     cout << m3 << "\n";
 
-    Matrix<int> m4(Shape(3, 3), IdentityMatrix());
-    cout << "Construct an identity matrix whose shape is (3, 3):\n";
+    Matrix<int> m4(Shape(4, 3), IdentityMatrix());
+    cout << "Construct an identity matrix whose shape is (4, 3):\n";
     cout << m4 << "\n";
 
-    Matrix<int> m5(Shape(3, 4), IdentityMatrix());
-    cout << "Construct an identity matrix whose shape is (3, 4):\n";
+    Matrix<int> m5({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}});
+    cout << "Construct an matrix from a std::initializer_list:\n";
     cout << m5 << "\n";
 
-    Matrix<int> m6(Shape(4, 3), IdentityMatrix());
-    cout << "Construct an identity matrix whose shape is (4, 3):\n";
+    Matrix<int> m6(vector<vector<int>>{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}});
+    cout << "Construct an matrix from a std::vector:\n";
     cout << m6 << "\n";
+
+    constexpr size_t len = 6;
+    unique_ptr<int[]> data = make_unique<int[]>(len);
+    for (int i = 0; i < len; i++) {
+        data[i] = i + 1;
+    }
+    Matrix<int> m7(Shape(3, 3), data.get(), len);
+    cout << "Construct an matrix from a raw pointer (the last three elements will be 0):\n";
+    cout << m7 << "\n";
+
+    int arr[len] = {1, 2, 3, 4, 5, 6};
+    Matrix<int> m8(Shape(3, 3), arr);
+    cout << "Construct an matrix from a raw array (the last three elements will be 0):\n";
+    cout << m8 << "\n";
+
+    array<int, len> stdArr = {1, 2, 3, 4, 5, 6};
+    Matrix<int> m9(Shape(3, 3), stdArr);
+    cout << "Construct an matrix from a std::array (the last three elements will be 0):\n";
+    cout << m9 << "\n";
+
+    Matrix<int> m10(Shape(3, 3));
+    cout << "Construct a matrix whose shape is (3, 3) and elements are all int():\n";
+    cout << m10 << "\n";
+
+    Matrix<int> m11(Shape(3, 3), -1);
+    cout << "Construct a matrix whose shape is (3, 3) and elements are all -1:\n";
+    cout << m11 << "\n";
+
+    Matrix<int> m12(Diag({1, 2, 3}));
+    cout << "Construct a diagonal matrix:\n";
+    cout << m12 << "\n";
+
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization): allow examples to copy
+    Matrix<int> m13 = m12;
+    cout << "Copy a matrix:\n";
+    cout << m13 << "\n";
+
+    Matrix<int> m14 = std::move(m13);
+    cout << "Move a matrix:\n";
+    cout << m14;
+    cout << "After move, the moved matrix will be empty:\n";
+    cout << m13 << "\n";
 
     return 0;
 }

--- a/src/include/mca/matrix.h
+++ b/src/include/mca/matrix.h
@@ -181,9 +181,7 @@ public:
                           });
         return *this;
     }
-    inline Matrix &operator=(const Matrix &other) {
-        return operator=<value_type>(other);
-    }
+    inline Matrix &operator=(const Matrix &other) { return operator=<value_type>(other); }
 
     /* Get the reference to the element of i-th row, j-th column */
     inline reference get(const size_type &i, const size_type &j) {

--- a/src/include/mca/matrix.h
+++ b/src/include/mca/matrix.h
@@ -168,7 +168,7 @@ public:
      * If other's value_type is not same with current matrix's,
      * the other's elements will be cast to the current matrix's value_type with static_cast<> */
     template <class T1>
-    inline Matrix<value_type> &operator=(const Matrix<T1> &other) {
+    inline Matrix &operator=(const Matrix<T1> &other) {
         allocateMemory(other.shape());
         calculationHelper(Operation::MATRIX_COPY_ASSIGNMENT,
                           size(),
@@ -181,7 +181,7 @@ public:
                           });
         return *this;
     }
-    inline Matrix<value_type> &operator=(const Matrix &other) {
+    inline Matrix &operator=(const Matrix &other) {
         return operator=<value_type>(other);
     }
 
@@ -284,9 +284,8 @@ public:
      *              a.pow(2)
      *              return:  [[5, 8],
      *                        [8, 13]] */
-    //     void pow(const size_type &exponent, Matrix<O> &output) const;
     inline Matrix pow(const size_type &exponent) const {
-        assert(isSquare());
+        assert(square());
         Matrix<value_type> output(shape());
         mca::pow(*this, exponent, output);
         return output;
@@ -308,11 +307,11 @@ public:
     }
 
     /* Check if the matrix is a square matrix */
-    inline bool isSquare() const noexcept { return rows() == columns(); }
+    inline bool square() const noexcept { return rows() == columns(); }
 
     /* Check if the matrix is symmetric with multi-thread */
     inline bool symmetric() const {
-        if (!isSquare()) { return false; }
+        if (!square()) { return false; }
         bool result = false;
         calculationHelper(Operation::MATRIX_SYMMETRIC,
                           size(),
@@ -326,7 +325,7 @@ public:
 
     /* Check if the matrix is antisymmetric with multi-thread */
     inline bool antisymmetric() const {
-        if (!isSquare()) { return false; }
+        if (!square()) { return false; }
         bool result = false;
         calculationHelper(Operation::MATRIX_ANTISYMMETRIC,
                           size(),

--- a/src/include/mca/mca.h
+++ b/src/include/mca/mca.h
@@ -661,7 +661,7 @@ inline void transpose(const Matrix<T> &a, Matrix<O> &output) {
 
 template <class T>
 inline void pow(Matrix<T> &a, const size_type &exponent) {
-    assert(a.isSquare());
+    assert(a.square());
     Matrix<T> output(a.shape());
     pow(a, exponent, output);
     a = std::move(output);
@@ -669,7 +669,7 @@ inline void pow(Matrix<T> &a, const size_type &exponent) {
 
 template <class T, class O, class>
 void pow(const Matrix<T> &a, const size_type &exponent, Matrix<O> &output) {
-    assert(a.isSquare());
+    assert(a.square());
     assert(a.shape() == output.shape());
     size_type b = exponent;
     Matrix<T> temp(a);

--- a/src/include/mca/shape.h
+++ b/src/include/mca/shape.h
@@ -14,18 +14,16 @@ struct Shape {
 
     inline Shape(const Shape &) = default;
 
-    inline Shape(Shape &&other) noexcept {
-        *this = std::move(other);
-    }
+    inline Shape(Shape &&other) noexcept { *this = std::move(other); }
 
     inline explicit Shape(const size_type &rows, const size_type &columns)
         : rows(rows), columns(columns) {}
 
     inline Shape &operator=(const Shape &other) = default;
- 
-    inline void operator = (Shape &&other) noexcept {
-        rows    = other.rows;
-        columns = other.columns;
+
+    inline void operator=(Shape &&other) noexcept {
+        rows       = other.rows;
+        columns    = other.columns;
         other.rows = other.columns = 0;
     }
 

--- a/src/include/mca/shape.h
+++ b/src/include/mca/shape.h
@@ -1,6 +1,7 @@
 #ifndef MCA_SHAPE_H
 #define MCA_SHAPE_H
 
+#include <algorithm>
 #include <cstddef>
 
 namespace mca {
@@ -11,8 +12,22 @@ struct Shape {
 
     inline Shape() = default;
 
+    inline Shape(const Shape &) = default;
+
+    inline Shape(Shape &&other) noexcept {
+        *this = std::move(other);
+    }
+
     inline explicit Shape(const size_type &rows, const size_type &columns)
         : rows(rows), columns(columns) {}
+
+    inline Shape &operator=(const Shape &other) = default;
+ 
+    inline void operator = (Shape &&other) noexcept {
+        rows    = other.rows;
+        columns = other.columns;
+        other.rows = other.columns = 0;
+    }
 
     inline bool operator==(const Shape &other) const noexcept {
         return rows == other.rows && columns == other.columns;

--- a/test/src/matrix_test.cpp
+++ b/test/src/matrix_test.cpp
@@ -154,9 +154,9 @@ TEST(TestMatrix, reshape) {
 
 TEST(TestMatrix, isSquare) {
     Matrix<int> m(Shape{3, 3});
-    ASSERT_TRUE(m.isSquare());
+    ASSERT_TRUE(m.square());
     m.reshape(Shape{1, 9});
-    ASSERT_FALSE(m.isSquare());
+    ASSERT_FALSE(m.square());
 }
 
 TEST(TestMatrix, iterators) {


### PR DESCRIPTION
Finish documents

During writing docs, we find some bugs, and fix them:
* The move constructor of `Shape` will not set the origin be 0.
* Update `isSquare` with `square` to be consistent with `symmetric` and  `antisymmetric`.
* Remove some redundant contents.

See #120.

Besides, we add `.root` in `.gitignore`